### PR TITLE
Set default FLASK_UPLOAD_FOLDER

### DIFF
--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -34,10 +34,10 @@ make test
 # Install environment variables.
 cat << "EOF" > .env
 # To see what these environment variables mean and how we use them in the
-# application, see `config.py`.
+# application, see \`config.py\`.
 
 FLASK_ENV=development
-# FLASK_UPLOAD_FOLDER="<absolute path to where you want to store uploads.>"
+FLASK_UPLOAD_FOLDER="$(pwd)/data/file-uploads"
 SQLALCHEMY_DATABASE_URI="sqlite:///database.db"
 
 GOOGLE_APPLICATION_CREDENTIALS="<Google API credentials>"


### PR DESCRIPTION
Otherwise, I have to set the upload folder manually when starting up ambuda for the first time -- 

<img width="684" alt="image" src="https://user-images.githubusercontent.com/1689183/183307372-fe48111b-44e2-4cdb-bc56-b725359d141a.png">
