### PR TITLE
Add cleaner config setup and comments

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -36,7 +36,9 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: python3 -m pip install -r requirements.txt
+        run: |
+          python3 -m pip install -r requirements.txt
+          npm install
       
       - name: Lint
         run: make lint-check

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           python-version: '3.9.x'
           cache: 'pip'
+          cache-dependency-path: requirements.txt
 
       - uses: actions/setup-node@v3
         with:
@@ -35,10 +36,10 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: make install
+        run: python3 -m pip install -r requirements.txt
       
       - name: Lint
-        run: source env/bin/activate && make lint-check
+        run: make lint-check
   
   run-tests:
     runs-on: ubuntu-22.04

--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -58,7 +58,7 @@ def _initialize_db_session(app, config_name: str):
         """Reset session state to prevent caching and memory leaks."""
         queries.get_session_class().remove()
 
-    if config_name == "production":
+    if config_name == config.PRODUCTION:
         # The hook below hides database errors. So, install the hook only if
         # we're in production.
 
@@ -69,36 +69,25 @@ def _initialize_db_session(app, config_name: str):
             session.rollback()
 
 
-def _validate_config(config):
-    """Raise an exception if the config is invalid in some way.
+def create_app(config_env: str):
+    """Initialize the Ambuda application."""
 
-    We raise an exception so that we can fail fast and avoid running with a
-    buggy config that could potentially corrupt the database.
-    """
-    if not config["UPLOAD_FOLDER"]:
-        raise ValueError("UPLOAD_FOLDER must be defined. See `.env` for details.")
-    if not Path(config["UPLOAD_FOLDER"]).is_absolute():
-        raise ValueError("UPLOAD_FOLDER must be an absolute path.")
-
-
-def create_app(config_name: str):
     # We store all env variables in a `.env` file so that it's easier to manage
     # different configurations.
     load_dotenv(".env")
 
     # Initialize Sentry monitoring only in production so that our Sentry page
     # contains only production warnings (as opposed to dev warnings).
-    if config_name == "production":
+    if config_env == config.PRODUCTION:
         _initialize_sentry()
 
     app = Flask(__name__)
 
     # Config
-    app.config.from_object(config.config[config_name])
-    _validate_config(app.config)
+    app.config.from_object(config.load_config_object(config_env))
 
     # Database
-    _initialize_db_session(app, config_name)
+    _initialize_db_session(app, config_env)
 
     # Extensions
     login_manager = auth_manager.create_login_manager()

--- a/config.py
+++ b/config.py
@@ -74,18 +74,25 @@ class BaseConfig:
     #: Where to store user uploads (PDFs, images, etc.).
     UPLOAD_FOLDER = _env("FLASK_UPLOAD_FOLDER")
 
+    # Extensions
+    # ----------
+
+    #: If True, enable cross-site request forgery (CSRF) protection.
+    #: This must be True in production.
+    WTF_CSRF_ENABLED = True
+
     # Services
     # --------
-
-    #: Sentry data source name (DSN)
-    #: We use Sentry to get notifications about server errors.
-    SENTRY_DSN = _env("SENTRY_DSN")
 
     #: ReCAPTCHA public key.
     RECAPTCHA_PUBLIC_KEY = _env("RECAPTCHA_PUBLIC_KEY")
 
     #: ReCAPTCHA private key.
     RECAPTCHA_PRIVATE_KEY = _env("RECAPTCHA_PRIVATE_KEY")
+
+    #: Sentry data source name (DSN)
+    #: We use Sentry to get notifications about server errors.
+    SENTRY_DSN = _env("SENTRY_DSN")
 
     # We need GOOGLE_APPLICATION_CREDENTIALS for the Google Vision API,
     # but these credentials are fetched by the Google API implicitly,

--- a/config.py
+++ b/config.py
@@ -1,3 +1,20 @@
+"""Config management for the Ambuda Flask app.
+
+All of Ambuda's interesting config values are defined in the project's `.env`
+file. Here, we parse that file and map its values to specific config objects,
+which we then load into Flask.
+
+Most config values are documented on :class:`BaseConfig`, from which all other
+classes inherit. Production-specific config values, which are mainly replated
+to deployment, are defined on :class:`ProductionConfig`.
+
+It's considered a best practice to keep this module outside the application
+package: From the Flask docs (emphasis added):
+
+    Configuration becomes more useful if you can store it in a separate file,
+    *ideally located outside the actual application package*.
+"""
+
 import os
 from pathlib import Path
 from typing import Optional
@@ -6,7 +23,15 @@ from dotenv import load_dotenv
 from flask import Flask
 
 
+# Load dotenv early so that `_env` will work in the class definitions below.
 load_dotenv()
+
+#: The test environment. For unit tests only.
+TESTING = "testing"
+#: The development environment. For local development.
+DEVELOPMENT = "development"
+#: The production environment. For production serving.
+PRODUCTION = "production"
 
 
 def _make_path(path: Path):
@@ -14,7 +39,7 @@ def _make_path(path: Path):
     return path
 
 
-def _env(key: str, default=None) -> str:
+def _env(key: str, default=None) -> Optional[str]:
     """Fetch a value from the local environment.
 
     :param key: the envvar to fetch
@@ -22,10 +47,55 @@ def _env(key: str, default=None) -> str:
     return os.environ.get(key, default)
 
 
-class UnitTestConfig:
+class BaseConfig:
+    """Base settings for all configs."""
+
+    # Core settings
+    # -------------
+
+    #: The Flask app environment ("production", "development", etc.). We set
+    #: this explicitly so that Celery can have access to it and load an
+    #: appropriate application context.
+    AMBUDA_ENVIRONMENT = None
+
+    #: Internal secret key for encrypting sensitive data.
+    SECRET_KEY = _env("SECRET_KEY")
+
+    #: Location of the Ambuda database.
+    SQLALCHEMY_DATABASE_URI = _env("SQLALCHEMY_DATABASE_URI")
+
+    #: Where to store user uploads (PDFs, images, etc.).
+    UPLOAD_FOLDER = _env("FLASK_UPLOAD_FOLDER")
+
+    # Extensions
+    # ----------
+
+    #: If True, enable cross-site request forgery (CSRF) protection.
+    WTF_CSRF_ENABLED = True
+
+    # Services
+    # --------
+
+    #: ReCAPTCHA public key.
+    RECAPTCHA_PUBLIC_KEY = _env("RECAPTCHA_PUBLIC_KEY")
+
+    #: ReCAPTCHA private key.
+    RECAPTCHA_PRIVATE_KEY = _env("RECAPTCHA_PRIVATE_KEY")
+
+    # Test-only
+    # ---------
+
+    #: If ``True``, enable the Flask debugger.
+    DEBUG = False
+
+    #: If ``True``, enable testing mode.
+    TESTING = False
+
+
+class UnitTestConfig(BaseConfig):
     """For unit tests."""
 
-    AMBUDA_ENVIRONMENT = "testing"
+    AMBUDA_ENVIRONMENT = TESTING
     TESTING = True
     SECRET_KEY = "insecure unit test secret"
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
@@ -36,29 +106,20 @@ class UnitTestConfig:
     RECAPTCHA_PRIVATE_KEY = "re-private"
 
 
-class DevelopmentConfig:
+class DevelopmentConfig(BaseConfig):
     """For local development."""
 
-    AMBUDA_ENVIRONMENT = "development"
+    AMBUDA_ENVIRONMENT = DEVELOPMENT
     DEBUG = True
-    SECRET_KEY = "insecure local secret"
-    SQLALCHEMY_DATABASE_URI = _env("SQLALCHEMY_DATABASE_URI")
-
-    UPLOAD_FOLDER = _env("FLASK_UPLOAD_FOLDER")
-
-    RECAPTCHA_PUBLIC_KEY = _env("RECAPTCHA_PUBLIC_KEY", "re-public")
-    RECAPTCHA_PRIVATE_KEY = _env("RECAPTCHA_PRIVATE_KEY", "re-private")
 
 
-class ProductionConfig:
+class ProductionConfig(BaseConfig):
     """For production."""
 
-    AMBUDA_ENVIRONMENT = "production"
-    SECRET_KEY = _env("SECRET_KEY")
-    SQLALCHEMY_DATABASE_URI = _env("SQLALCHEMY_DATABASE_URI")
+    AMBUDA_ENVIRONMENT = PRODUCTION
 
-    #: File upload settings
-    UPLOAD_FOLDER = _env("FLASK_UPLOAD_FOLDER")
+    # Deployment credentials
+    # ----------------------
 
     #: Which directory to use on the production machine.
     APP_DIRECTORY = _env("APP_DIRECTORY")
@@ -67,17 +128,45 @@ class ProductionConfig:
     #: Server host.
     APP_SERVER_HOST = _env("APP_SERVER_HOST")
 
-    # Recaptcha settings
-    RECAPTCHA_PUBLIC_KEY = _env("RECAPTCHA_PUBLIC_KEY")
-    RECAPTCHA_PRIVATE_KEY = _env("RECAPTCHA_PRIVATE_KEY")
+
+def _validate_config(config: BaseConfig):
+    """Examine the given config and fail if the config is malformed.
+
+    :param config: the config to test
+    """
+    assert config.AMBUDA_ENVIRONMENT in {TESTING, DEVELOPMENT, PRODUCTION}
+
+    if not config.SQLALCHEMY_DATABASE_URI:
+        raise ValueError("This config does not define SQLALCHEMY_DATABASE_URI")
+    if not config.UPLOAD_FOLDER:
+        raise ValueError("This config does not define UPLOAD_FOLDER.")
+    if not Path(config.UPLOAD_FOLDER).is_absolute():
+        raise ValueError("UPLOAD_FOLDER must be an absolute path.")
+
+    # Production-specific validation.
+    if config.AMBUDA_ENVIRONMENT == PRODUCTION:
+        # All keys must be set.
+        for key in dir(config):
+            if key.isupper():
+                value = getattr(config, key)
+                assert value, key
+
+        # App must not be in debug/test mode.
+        assert config.WTF_CSRF_ENABLED
+        assert not config.DEBUG
+        assert not config.TESTING
 
 
-config = {
-    "testing": UnitTestConfig,
-    "development": DevelopmentConfig,
-    "production": ProductionConfig,
-    "default": DevelopmentConfig,
-}
+def load_config_object(name: str):
+    """Load and validate an application config."""
+    config_map = {
+        TESTING: UnitTestConfig,
+        DEVELOPMENT: DevelopmentConfig,
+        PRODUCTION: ProductionConfig,
+    }
+    config = config_map[name]
+    _validate_config(config)
+    return config
 
 
 def create_config_only_app(config_name: str):
@@ -88,5 +177,5 @@ def create_config_only_app(config_name: str):
     """
     load_dotenv(".env")
     app = Flask(__name__)
-    app.config.from_object(config[config_name])
+    app.config.from_object(load_config_object(config_name))
     return app

--- a/config.py
+++ b/config.py
@@ -61,24 +61,25 @@ class BaseConfig:
     #: Internal secret key for encrypting sensitive data.
     SECRET_KEY = _env("SECRET_KEY")
 
-    #: Location of the Ambuda database.
+    #: URI for the Ambuda database. This URI (also called a URL in some docs)
+    #: has the following basic format:
+    #:
+    #:     dialect+driver://username:password@host:port/database
+    #:
+    #: For more information, see:
+    #:
+    #: https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
     SQLALCHEMY_DATABASE_URI = _env("SQLALCHEMY_DATABASE_URI")
 
     #: Where to store user uploads (PDFs, images, etc.).
     UPLOAD_FOLDER = _env("FLASK_UPLOAD_FOLDER")
-
-    # Extensions
-    # ----------
-
-    #: If True, enable cross-site request forgery (CSRF) protection.
-    WTF_CSRF_ENABLED = True
 
     # Services
     # --------
 
     #: Sentry data source name (DSN)
     #: We use Sentry to get notifications about server errors.
-    SENTRY_DSN = None
+    SENTRY_DSN = _env("SENTRY_DSN")
 
     #: ReCAPTCHA public key.
     RECAPTCHA_PUBLIC_KEY = _env("RECAPTCHA_PUBLIC_KEY")
@@ -108,6 +109,9 @@ class UnitTestConfig(BaseConfig):
     SECRET_KEY = "insecure unit test secret"
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     UPLOAD_FOLDER = _make_path(Path(__file__).parent / "data" / "file-uploads")
+
+    #: Disable CSRF protection for unit tests, since the Flask test runner
+    #: doesn't have good support for it.
     WTF_CSRF_ENABLED = False
 
     RECAPTCHA_PUBLIC_KEY = "re-public"

--- a/config.py
+++ b/config.py
@@ -76,11 +76,19 @@ class BaseConfig:
     # Services
     # --------
 
+    #: Sentry data source name (DSN)
+    #: We use Sentry to get notifications about server errors.
+    SENTRY_DSN = None
+
     #: ReCAPTCHA public key.
     RECAPTCHA_PUBLIC_KEY = _env("RECAPTCHA_PUBLIC_KEY")
 
     #: ReCAPTCHA private key.
     RECAPTCHA_PRIVATE_KEY = _env("RECAPTCHA_PRIVATE_KEY")
+
+    # We need GOOGLE_APPLICATION_CREDENTIALS for the Google Vision API,
+    # but these credentials are fetched by the Google API implicitly,
+    # so we don't need to define it on the Config object here.
 
     # Test-only
     # ---------
@@ -155,6 +163,11 @@ def _validate_config(config: BaseConfig):
         assert config.WTF_CSRF_ENABLED
         assert not config.DEBUG
         assert not config.TESTING
+
+        # Google credentials must be set and exist.
+        google_creds = _env("GOOGLE_APPLICATION_CREDENTIALS")
+        assert google_creds
+        assert Path(google_creds).exists()
 
 
 def load_config_object(name: str):

--- a/scripts/initialize_db.py
+++ b/scripts/initialize_db.py
@@ -18,7 +18,7 @@ load_dotenv()
 
 
 def run():
-    conf = config.config["development"]
+    conf = config.load_config_object("development")
     engine = create_engine(conf.SQLALCHEMY_DATABASE_URI)
     db.Base.metadata.create_all(engine)
 


### PR DESCRIPTION
All config values are defined and documented on a `BaseConfig` from which all config schemas inherit. Further, I added extra validation checks to ensure that our configs are well-formed.

The one thing I dislike here is that `_env` will happily return None if an environment variable can't be found. It has this behavior (as opposed to just failing) because otherwise, class initialization will fail if a value is defined and we won't be able to import the module.

The workarounds to this that I can think of are clumsy:
- configs in separate modules, dynamically import as needed
- initialize classes in wrapped functions that run only when called
- list all environment variables on `.env` on startup, even if they're empty strings

Maybe the third one isn't so bad.