### PR TITLE
Add explicit CC0 statement to page edit form

### DIFF
--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -70,6 +70,10 @@
       {{ form.status.label(class_="text-slate-600 mb-2 block") }}
       {{ form.status(class_="block rounded bg-white w-full mb-4 p-2") }}
 
+      {% set cc0 = "https://creativecommons.org/publicdomain/zero/1.0/" %}
+      <p class="my-4 text-sm">By saving your changes, you agree to release your
+      contribution under the <a class="underline" href="{{ cc0 }}">CC0 (public
+      domain) license</a>.</p>
       <input class="btn btn-submit" type="submit" value="Publish changes">
     </div>
   </form>


### PR DESCRIPTION
This makes an implicit point explicit: our contributions, to the extent
that they have copyright in different jurisdictions, should be dedicated
to the public domain. My understanding is that the digital text that we
produce on Ambuda will thus have the same access permissions as the
original book on which it is based.