### PR TITLE
Verify the production setup before deploying

### DIFF
--- a/ambuda/tasks/projects.py
+++ b/ambuda/tasks/projects.py
@@ -1,6 +1,5 @@
 """Background tasks for proofing projects."""
 
-import subprocess
 from pathlib import Path
 
 import fitz

--- a/config.py
+++ b/config.py
@@ -141,11 +141,11 @@ class ProductionConfig(BaseConfig):
     # ----------------------
 
     #: Which directory to use on the production machine.
-    APP_DIRECTORY = _env("SERVER_APP_DIRECTORY")
+    SERVER_APP_DIRECTORY = _env("SERVER_APP_DIRECTORY")
     #: Server username.
-    APP_SERVER_USER = _env("SERVER_USER")
+    SERVER_USER = _env("SERVER_USER")
     #: Server host.
-    APP_SERVER_HOST = _env("SERVER_HOST")
+    SERVER_HOST = _env("SERVER_HOST")
 
 
 def _validate_config(config: BaseConfig):

--- a/config.py
+++ b/config.py
@@ -141,11 +141,11 @@ class ProductionConfig(BaseConfig):
     # ----------------------
 
     #: Which directory to use on the production machine.
-    APP_DIRECTORY = _env("APP_DIRECTORY")
+    APP_DIRECTORY = _env("SERVER_APP_DIRECTORY")
     #: Server username.
-    APP_SERVER_USER = _env("APP_SERVER_USER")
+    APP_SERVER_USER = _env("SERVER_USER")
     #: Server host.
-    APP_SERVER_HOST = _env("APP_SERVER_HOST")
+    APP_SERVER_HOST = _env("SERVER_HOST")
 
 
 def _validate_config(config: BaseConfig):
@@ -168,7 +168,7 @@ def _validate_config(config: BaseConfig):
         for key in dir(config):
             if key.isupper():
                 value = getattr(config, key)
-                assert value, key
+                assert value is not None, f"Config param {key} must not be `None`"
 
         # App must not be in debug/test mode.
         assert config.WTF_CSRF_ENABLED

--- a/fabfile.py
+++ b/fabfile.py
@@ -81,9 +81,15 @@ def deploy_to_commit(_, pointer: str):
 
         upgrade_db(_)
 
+        # Verify that unit tests pass on prod.
+        c.run("make test")
+
         # Copy production config settings.
         env_path = str(APP_DIRECTORY / ".env")
         c.put("production/prod-env", env_path)
+
+        # Verify that the production setup is well-formed.
+        c.run("python -m scripts.check_prod_setup")
 
     restart_application(_)
     restart_celery(_)

--- a/scripts/check_prod_setup.py
+++ b/scripts/check_prod_setup.py
@@ -1,0 +1,10 @@
+"""Verifies that the local `.env` file is a is well-formed production config.
+
+NOTE: run this script in the production environment.
+"""
+
+import config
+from config import create_config_only_app
+
+# Fails if config is malformed.
+app = create_config_only_app("production")


### PR DESCRIPTION
This commit adds some basic checks that test the production setup before
deploying a new instance. If any of these checks fail, we should abort
the deploy.