### PR TITLE
Fix typo in .env file creation

### DIFF
--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -32,7 +32,7 @@ pip install -r requirements.txt
 make test
 
 # Install environment variables.
-cat << "EOF" > .env
+cat << EOF > .env
 # To see what these environment variables mean and how we use them in the
 # application, see \`config.py\`.
 


### PR DESCRIPTION
"EOF" must be un-quoted in order for variable substitution to actually be evaluated. Follow-up to https://github.com/ambuda-org/ambuda/pull/87.