### PR TITLE
Add project creator_id, created_at, and updated_at

### DIFF
--- a/ambuda/admin.py
+++ b/ambuda/admin.py
@@ -39,6 +39,10 @@ class TextView(BaseView):
     column_list = form_columns = ["slug", "title"]
 
 
+class ProjectView(BaseView):
+    column_list = form_columns = ["slug", "title", "creator_id"]
+
+
 class DictionaryView(BaseView):
     column_list = form_columns = ["slug", "title"]
 
@@ -47,6 +51,7 @@ def create_admin_manager(app):
     session = q.get_session_class()
     admin = Admin(app, name="Ambuda", index_view=AmbudaIndexView())
     admin.add_view(DictionaryView(db.Dictionary, session))
+    admin.add_view(ProjectView(db.Project, session))
     admin.add_view(TextBlockView(db.TextBlock, session))
     admin.add_view(TextView(db.Text, session))
     admin.add_view(UserView(db.User, session))

--- a/ambuda/models/base.py
+++ b/ambuda/models/base.py
@@ -24,3 +24,12 @@ def pk():
 def foreign_key(field: str):
     """Define a simple foreign key."""
     return Column(Integer, ForeignKey(field), nullable=False, index=True)
+
+
+def same_as(column_name: str):
+    """Utility for setting one column's default value to another column."""
+
+    def default_function(context):
+        return context.current_parameters.get(column_name)
+
+    return default_function

--- a/ambuda/models/proofing.py
+++ b/ambuda/models/proofing.py
@@ -60,6 +60,7 @@ class Project(Base):
     #: FIXME: make non-nullable once we manually migrate the production setup.
     creator_id = Column(Integer, ForeignKey("users.id"), index=True)
 
+    creator = relationship("User")
     board = relationship("Board", cascade="delete")
 
     #: An ordered list of pages belonging to this project.

--- a/ambuda/models/proofing.py
+++ b/ambuda/models/proofing.py
@@ -10,7 +10,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
-from ambuda.models.base import Base, pk, foreign_key
+from ambuda.models.base import Base, pk, foreign_key, same_as
 
 
 def string():
@@ -49,8 +49,16 @@ class Project(Base):
     #: Defines page numbers (e.g. "x", "vii", ...)
     page_numbers = text()
 
+    #: Timestamp at which this project was created.
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    #: Timestamp at which this project was last updated.
+    updated_at = Column(DateTime, default=same_as("created_at"), nullable=False)
+
     #: Discussion board for this project.
     board_id = foreign_key("discussion_boards.id")
+    #: Creator of this project.
+    #: FIXME: make non-nullable once we manually migrate the production setup.
+    creator_id = Column(Integer, ForeignKey("users.id"), index=True)
 
     board = relationship("Board", cascade="delete")
 
@@ -132,6 +140,7 @@ class Revision(Base):
         Integer, ForeignKey("proof_page_statuses.id"), index=True, nullable=False
     )
     #: Timestamp at which this revision was created.
+    #: FIXME: rename to `created_at` for consistency with other models.
     created = Column(DateTime, default=datetime.utcnow, nullable=False)
     #: An optional editor summary for this revision.
     summary = Column(Text_, nullable=False, default="")

--- a/ambuda/models/talk.py
+++ b/ambuda/models/talk.py
@@ -12,21 +12,12 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
-from ambuda.models.base import Base, pk, foreign_key
+from ambuda.models.base import Base, pk, foreign_key, same_as
 
 
 def string():
     """Create a non-nullable string column that defaults to the empty string."""
     return Column(String, nullable=False, default="")
-
-
-def same_as(column_name):
-    """Utility for setting one column's default value to another column."""
-
-    def default_function(context):
-        return context.current_parameters.get(column_name)
-
-    return default_function
 
 
 class Board(Base):

--- a/ambuda/queries.py
+++ b/ambuda/queries.py
@@ -160,14 +160,14 @@ def project(slug: str) -> Optional[db.Project]:
     return session.query(db.Project).filter(db.Project.slug == slug).first()
 
 
-def create_project(*, title: str, slug: str):
+def create_project(*, title: str, slug: str, creator_id: int):
     session = get_session()
 
     board = db.Board(title=f"{slug} discussion board")
     session.add(board)
     session.flush()
 
-    project = db.Project(slug=slug, title=title)
+    project = db.Project(slug=slug, title=title, creator_id=creator_id)
     project.board_id = board.id
 
     session.add(project)

--- a/ambuda/tasks/projects.py
+++ b/ambuda/tasks/projects.py
@@ -61,11 +61,7 @@ def _split_pdf_into_pages(
     return doc.page_count
 
 
-def _add_project_to_database(
-    title: str,
-    slug: str,
-    num_pages: int,
-):
+def _add_project_to_database(title: str, slug: str, num_pages: int, creator_id: int):
     """Create a project on the database.
 
     :param title: the project title
@@ -78,7 +74,7 @@ def _add_project_to_database(
     session.add(board)
     session.flush()
 
-    project = db.Project(slug=slug, title=title)
+    project = db.Project(slug=slug, title=title, creator_id=creator_id)
     project.board_id = board.id
     session.add(project)
     session.flush()
@@ -101,7 +97,12 @@ def _add_project_to_database(
 
 @app.task(bind=True)
 def create_project(
-    self, title: str, pdf_path: str, output_dir: str, app_environment: str
+    self,
+    title: str,
+    pdf_path: str,
+    output_dir: str,
+    app_environment: str,
+    creator_id: int,
 ):
     """Split the given PDF into pages and register the project on the database.
 
@@ -134,6 +135,7 @@ def create_project(
             title=title,
             slug=slug,
             num_pages=num_pages,
+            creator_id=creator_id,
         )
 
     task_status.success(num_pages, slug)

--- a/ambuda/templates/proofing/projects/admin.html
+++ b/ambuda/templates/proofing/projects/admin.html
@@ -11,6 +11,16 @@
 
 <div class="prose">
 
+<h2>Summary</h2>
+
+{% if project.creator %}
+{% set user_link = url_for('proofing.users.user', username=project.creator.username) %}
+<p>Created by <a href="{{ user_link }}">{{ project.creator.username }}</a>
+{{ project.created_at|time_ago }}.</p>
+{% else %}
+<p>Created by <i>(unknown user)</i> {{ project.created_at|time_ago }}.</p>
+{% endif %}
+
 
 <h2>Danger zone</h2>
 

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -14,7 +14,7 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import login_required
+from flask_login import current_user, login_required
 from flask_wtf import FlaskForm
 from slugify import slugify
 from werkzeug.utils import secure_filename
@@ -116,6 +116,7 @@ def create_project():
             pdf_path=str(pdf_path),
             output_dir=str(page_image_dir),
             app_environment=current_app.config["AMBUDA_ENVIRONMENT"],
+            creator_id=current_user.id,
         )
         return render_template(
             "proofing/create-project-post.html",

--- a/migrations/versions/82cf1fd072bb_add_project_creator_and_timestamps.py
+++ b/migrations/versions/82cf1fd072bb_add_project_creator_and_timestamps.py
@@ -1,0 +1,82 @@
+"""Add project creator and timestamps
+
+Revision ID: 82cf1fd072bb
+Revises: 66f49d23146f
+Create Date: 2022-08-13 07:14:52.325324
+
+"""
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "82cf1fd072bb"
+down_revision = "66f49d23146f"
+branch_labels = None
+depends_on = None
+
+
+Base = sa.orm.declarative_base()
+
+
+class Project(Base):
+    __tablename__ = "proof_projects"
+    id = sa.Column(sa.Integer, primary_key=True)
+    created_at = sa.Column(sa.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = sa.Column(sa.DateTime, default=datetime.utcnow, nullable=False)
+
+
+def upgrade() -> None:
+    # Create as non-null, add default values, then update to not-null.
+    op.add_column(
+        "proof_projects", sa.Column("created_at", sa.DateTime(), nullable=True)
+    )
+    op.add_column(
+        "proof_projects", sa.Column("updated_at", sa.DateTime(), nullable=True)
+    )
+
+    op.add_column(
+        "proof_projects", sa.Column("creator_id", sa.Integer(), nullable=True)
+    )
+    op.create_index(
+        op.f("ix_proof_projects_creator_id"),
+        "proof_projects",
+        ["creator_id"],
+        unique=False,
+    )
+
+    # Add defalut timestamps for all existing projects.
+    now = datetime.utcnow()
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+    for project in session.query(Project).all():
+        project.created_at = now
+        project.updated_at = now
+        session.add(project)
+    session.commit()
+
+    with op.batch_alter_table("proof_projects") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_proof_projects_creator_id_users", "users", ["creator_id"], ["id"]
+        )
+        batch_op.alter_column("created_at", existing_type=sa.DATETIME(), nullable=False)
+        batch_op.alter_column("updated_at", existing_type=sa.DATETIME(), nullable=False)
+
+
+def downgrade() -> None:
+    naming_convention = {
+        "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    }
+    with op.batch_alter_table(
+        "proof_projects", naming_convention=naming_convention
+    ) as batch_op:
+        batch_op.drop_constraint(
+            "fk_proof_projects_creator_id_users", type_="foreignkey"
+        )
+        # batch_op.drop_constraint('fk_proof_projects_creator_id_users', type_="foreignkey")
+    op.drop_index(op.f("ix_proof_projects_creator_id"), table_name="proof_projects")
+    op.drop_column("proof_projects", "creator_id")
+    op.drop_column("proof_projects", "updated_at")
+    op.drop_column("proof_projects", "created_at")

--- a/test/ambuda/tasks/test_projects_tasks.py
+++ b/test/ambuda/tasks/test_projects_tasks.py
@@ -6,7 +6,10 @@ def test_add_project_to_database(flask_app):
     with flask_app.app_context():
         assert not q.project("cool")
         projects._add_project_to_database(
-            title="Cool project", slug="cool", num_pages=100
+            title="Cool project",
+            slug="cool",
+            num_pages=100,
+            creator_id=1,
         )
         project = q.project("cool")
         assert project


### PR DESCRIPTION
`creator_id` tracks the project creator for better visibility into the
overall effort. This is nullable for now because we need to manually
migrate the production setup first.

`created_at` is likewise for better visibility, and it can show proofers
which projects have been in progress the longest.

`updated_at` is not useful now, but in the future, it can show proofers
which projects have been changed most recently.

Test plan: unit tests, ran `upgrade` and `downgrade` and `upgrade`
again.