### PR TITLE
Change HTML structure for text blocks

### DIFF
--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -352,10 +352,10 @@ const TextContent = (() => {
           // return;
         }
 
-        const $lg = e.target.closest('s-lg');
-        if ($lg) {
+        const $block = e.target.closest('s-block');
+        if ($block) {
           e.preventDefault();
-          ParseLayer.showParsedBlock($lg.id);
+          ParseLayer.showParsedBlock($block.id);
         }
       });
 

--- a/ambuda/templates/base.html
+++ b/ambuda/templates/base.html
@@ -11,7 +11,7 @@
     <title>{% block title %}{% endblock %}</title>
     <script async defer data-domain="ambuda.org" src="https://plausible.io/js/plausible.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/@indic-transliteration/sanscript@1.2.7/sanscript.min.js"></script>
-    <script defer src="/static/js/main.js?v=3"></script>
+    <script defer src="/static/js/main.js?v=4"></script>
   </head>
   {% block body %}{% endblock %}
 </html>

--- a/ambuda/templates/htmx/text-block.html
+++ b/ambuda/templates/htmx/text-block.html
@@ -1,1 +1,3 @@
-{{ content | safe }}
+<s-block id="{{ block.id }}">
+  {{ block.html | safe }}
+</s-block>

--- a/ambuda/templates/htmx/text-section.html
+++ b/ambuda/templates/htmx/text-section.html
@@ -31,7 +31,14 @@
   {% else %}
   <p lang="en" class="text-center text-xs text-zinc-400 mt-2 mb-4">Click on words to see what they mean.</p>
   {% endif %}
-  {{ content | safe }}
+
+  <div class="text-section">
+    {% for block_ in html_blocks %}
+    <s-block id="{{ block_.id }}">
+      <div class="mula">{{ block_.html|safe }}</div>
+    </s-block>
+    {% endfor %}
+  </div>
 </div>
 
 {# z-50 so that the footer renders on top of the sidebar. #}

--- a/ambuda/views/proofing/tagging.py
+++ b/ambuda/views/proofing/tagging.py
@@ -81,7 +81,7 @@ def edit_block(text_slug, block_slug):
     if block_parse is None:
         abort(404)
 
-    mula = xml.transform_tei(block.xml)
+    mula = xml.transform_text_block(block.xml).html
     tokens = cheda.extract_tokens(block_parse.data)
 
     form = EditBlockForm()

--- a/ambuda/views/reader/texts.py
+++ b/ambuda/views/reader/texts.py
@@ -123,8 +123,7 @@ def section(text_slug, section_slug):
     cur = q.text_section(text.id, section_slug)
 
     with q.get_session() as sess:
-        blob = "<div>" + "".join(b.xml for b in cur.blocks) + "</div>"
-        content = xml.transform_tei(blob)
+        html_blocks = [xml.transform_text_block(b.xml) for b in cur.blocks]
 
     has_no_parse = text.slug in HAS_NO_PARSE
 
@@ -134,7 +133,7 @@ def section(text_slug, section_slug):
         prev=prev,
         section=cur,
         next=next,
-        content=content,
+        html_blocks=html_blocks,
         has_no_parse=has_no_parse,
     )
 
@@ -154,8 +153,7 @@ def section_htmx(text_slug, section_slug):
     cur = q.text_section(text.id, section_slug)
 
     with q.get_session() as sess:
-        blob = "<div>" + "".join(b.xml for b in cur.blocks) + "</div>"
-        content = xml.transform_tei(blob)
+        html_blocks = [xml.transform_text_block(b.xml) for b in cur.blocks]
 
     return render_template(
         "htmx/text-section.html",
@@ -163,7 +161,7 @@ def section_htmx(text_slug, section_slug):
         prev=prev,
         section=cur,
         next=next,
-        content=content,
+        html_blocks=html_blocks,
     )
 
 
@@ -177,8 +175,8 @@ def block_htmx(text_slug, block_slug):
     if not block:
         abort(404)
 
-    content = xml.transform_tei(block.xml)
+    html_block = xml.transform_text_block(block.xml)
     return render_template(
         "htmx/text-block.html",
-        content=content,
+        block=html_block,
     )

--- a/test/ambuda/test_xml.py
+++ b/test/ambuda/test_xml.py
@@ -27,11 +27,11 @@ def test_paren__text_and_child():
     assert output == '<span class="paren">(test <b>foo</b>)</span>'
 
 
-def test_to_verse():
-    xml = ET.fromstring('<lg xml:id="Test">verse</lg>')
-    x.to_verse(xml)
-    assert xml.tag == "s-lg"
-    assert xml.attrib == {"id": "Test"}
+def test_transform_text_block():
+    blob = '<lg xml:id="Test">verse</lg>'
+    block = x.transform_text_block(blob)
+    assert block.id == "Test"
+    assert block.html == "<s-lg>verse</s-lg>"
 
 
 def test_transform():


### PR DESCRIPTION
All blocks now follow this simple structure:

    <s-block id="">
      <div class="mula">
        <!-- original content -->
      </div>
      <!-- other content -->
    </s-block>

`s-` (for Sanskrit) is our convention for custom elements. We can always
locate the containing block by searching for `closest("s-block")`.

Test plan: unit tests and tried the following tests on local host:
- click word
- click parsed word for dictionary entry
- show original