### PR TITLE
Fix rendering bug for editor textarea

### DIFF
--- a/ambuda/templates/base.html
+++ b/ambuda/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="description" content="{% block meta_description -%}
     A breakthrough Sanskrit library. Read our library of traditional Sanskrit texts with word-by-word analysis, integrated dictionary support, and so much more.
     {%- endblock %}">
-    <link rel="stylesheet" type="text/css" href="/static/gen/style.css?v=9">
+    <link rel="stylesheet" type="text/css" href="/static/gen/style.css?v=10">
     <link rel="icon" href="data:,">
     <title>{% block title %}{% endblock %}</title>
     {% block scripts %}{% endblock %}

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -129,7 +129,7 @@
         </div>
         <textarea id="content" name="content" required=""
           class="grow p-2 md:p-4 w-full resize-none"
-          :style="`font-size: ${textRatio}rem`"></textarea>
+          :style="`font-size: ${textRatio}rem`">{{ form.content.data or "" }}</textarea>
       </div>
 
       {# Raw image. #}


### PR DESCRIPTION
After recent changes for Alpine, this `<textarea>` is no longer
initialized with the server value, which can feel like a bug to end
users.