### PR TITLE
Only allow console.error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,6 @@ module.exports = {
     ecmaVersion: 'latest',
   },
   rules: {
-    "no-console": "off",
+    "no-console": ['error', { allow: ['error'] }]
   },
 };


### PR DESCRIPTION
Re-enables no-console eslint rule that was disabled in 9e89bcb293e75938bc35f0877bb26207d213b953.

See https://eslint.org/docs/latest/rules/no-console#options