### PR TITLE
Add dictionary.js and further split up main.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,8 @@ module.exports = {
     ecmaVersion: 'latest',
   },
   rules: {
-    "no-console": ['error', { allow: ['error'] }]
+    "no-console": ['error', { allow: ['error'] }],
+    // Temporarily disabled while we set up JS modules.
+    "no-unused-vars": "off"
   },
 };

--- a/ambuda/static/js/dictionary.js
+++ b/ambuda/static/js/dictionary.js
@@ -1,3 +1,5 @@
+/* global $, Server, transliterateHTMLString, transliterateElement, Alpine */
+
 const DICTIONARY_CONFIG_KEY = 'dictionary';
 const DictionaryAlpine = () => ({
   script: 'devanagari',
@@ -27,7 +29,6 @@ const DictionaryAlpine = () => ({
       source: this.source,
     };
     localStorage.setItem(DICTIONARY_CONFIG_KEY, JSON.stringify(settings));
-    console.log(settings);
   },
 
   setSource(value) {
@@ -62,9 +63,8 @@ const DictionaryAlpine = () => ({
 
   transliterate(oldScript, newScript) {
     transliterateElement($('#dict--response'), oldScript, newScript);
-  }
+  },
 });
-
 
 window.addEventListener('alpine:init', () => {
   Alpine.data('dictionary', DictionaryAlpine);

--- a/ambuda/static/js/dictionary.js
+++ b/ambuda/static/js/dictionary.js
@@ -1,4 +1,4 @@
-/* global $, Server, transliterateHTMLString, transliterateElement, Alpine */
+/* global $, Server, transliterateHTMLString, transliterateElement, Alpine, Routes */
 
 const DICTIONARY_CONFIG_KEY = 'dictionary';
 const DictionaryAlpine = () => ({
@@ -47,13 +47,13 @@ const DictionaryAlpine = () => ({
       return;
     }
 
-    const url = URL.ajaxDictionaryQuery(this.source, this.query);
+    const url = Routes.ajaxDictionaryQuery(this.source, this.query);
     const $container = $('#dict--response');
     Server.getText(
       url,
       (resp) => {
         $container.innerHTML = transliterateHTMLString(resp, this.script);
-        window.history.replaceState({}, '', URL.dictionaryQuery(this.source, this.query));
+        window.history.replaceState({}, '', Routes.dictionaryQuery(this.source, this.query));
       },
       () => {
         $container.innerHTML = '<p>Sorry, this content is not available right now.</p>';

--- a/ambuda/static/js/dictionary.js
+++ b/ambuda/static/js/dictionary.js
@@ -1,0 +1,71 @@
+const DICTIONARY_CONFIG_KEY = 'dictionary';
+const DictionaryAlpine = () => ({
+  script: 'devanagari',
+  source: 'mw',
+  query: '',
+
+  init() {
+    this.loadSettings();
+    this.transliterate('devanagari', this.script);
+  },
+
+  loadSettings() {
+    const settingsStr = localStorage.getItem(DICTIONARY_CONFIG_KEY);
+    if (settingsStr) {
+      try {
+        const settings = JSON.parse(settingsStr);
+        this.script = settings.script || this.script;
+        this.source = settings.source || this.source;
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  },
+  saveSettings() {
+    const settings = {
+      script: this.script,
+      source: this.source,
+    };
+    localStorage.setItem(DICTIONARY_CONFIG_KEY, JSON.stringify(settings));
+    console.log(settings);
+  },
+
+  setSource(value) {
+    this.source = value;
+    this.saveSettings();
+    this.searchDictionary(this.query);
+  },
+  setScript(value) {
+    this.transliterate(this.script, value);
+    this.script = value;
+    this.saveSettings();
+  },
+
+  searchDictionary() {
+    if (!this.query) {
+      return;
+    }
+
+    const url = URL.ajaxDictionaryQuery(this.source, this.query);
+    const $container = $('#dict--response');
+    Server.getText(
+      url,
+      (resp) => {
+        $container.innerHTML = transliterateHTMLString(resp, this.script);
+        window.history.replaceState({}, '', URL.dictionaryQuery(this.source, this.query));
+      },
+      () => {
+        $container.innerHTML = '<p>Sorry, this content is not available right now.</p>';
+      },
+    );
+  },
+
+  transliterate(oldScript, newScript) {
+    transliterateElement($('#dict--response'), oldScript, newScript);
+  }
+});
+
+
+window.addEventListener('alpine:init', () => {
+  Alpine.data('dictionary', DictionaryAlpine);
+});

--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -7,7 +7,7 @@
  * - `proofreading.js` defines the proofing environment.
  */
 
-const URL = {
+const Routes = {
   ajaxDictionaryQuery: (version, query) => `/api/dictionaries/${version}/${query}`,
   dictionaryQuery: (version, query) => `/tools/dictionaries/${version}/${query}`,
   parseData: (textSlug, blockSlug) => `/api/parses/${textSlug}/${blockSlug}`,
@@ -149,7 +149,7 @@ const Dictionary = (() => {
   function fetch(version, query, callback) {
     $('#dict--form input[name=q]').value = query;
 
-    const url = URL.ajaxDictionaryQuery(version, query);
+    const url = Routes.ajaxDictionaryQuery(version, query);
     const $container = $('#dict--response');
     Server.getText(
       url,
@@ -178,7 +178,7 @@ const Dictionary = (() => {
     fetch(version, query, () => {
       // FIXME: remove "startsWith" hack and move this to Dictionaries page.
       if (window.location.pathname.startsWith('/tools/dict')) {
-        window.history.replaceState({}, '', URL.dictionaryQuery(version, query));
+        window.history.replaceState({}, '', Routes.dictionaryQuery(version, query));
       }
     });
   }
@@ -212,7 +212,7 @@ const ParseLayer = (() => {
   function showParsedBlock(blockID) {
     const blockSlug = getBlockSlug(blockID);
     const $container = $('#parse--response');
-    const textSlug = URL.getTextSlug();
+    const textSlug = Routes.getTextSlug();
 
     const $block = $(`#${blockID.replaceAll('.', '\\.')}`);
 
@@ -224,7 +224,7 @@ const ParseLayer = (() => {
     $block.classList.add('has-parsed');
 
     // Fetch parsed data.
-    const url = URL.parseData(textSlug, blockSlug);
+    const url = Routes.parseData(textSlug, blockSlug);
     Server.getText(
       url,
       (resp) => {

--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -1,12 +1,7 @@
 /* global Sanscript */
+/* exported Routes Server transliterateSanskritBlob transliterateHTMLString */
 
-/* NOTE: This code is deprecated, and we're in the process of splitting it up
- * into separate files:
- *
- * - `reader.js` defines the reading environment.
- * - `proofreading.js` defines the proofing environment.
- */
-
+// A simple interface to server URLs.
 const Routes = {
   ajaxDictionaryQuery: (version, query) => `/api/dictionaries/${version}/${query}`,
   dictionaryQuery: (version, query) => `/tools/dictionaries/${version}/${query}`,
@@ -35,34 +30,6 @@ const Server = {
     };
     req.open('GET', url);
     req.send();
-  },
-};
-
-const Preferences = {
-  // FIXME: remove this once everything has been migrated to `reader.js`.
-  get contentScript() {
-    const ls = localStorage.getItem('user-script');
-    if (!ls || ls === 'undefined') {
-      return 'devanagari';
-    }
-    return ls;
-  },
-  set contentScript(value) {
-    if (value) {
-      localStorage.setItem('user-script', value);
-    }
-  },
-
-  get dictVersion() {
-    const val = localStorage.getItem('dict-version');
-    if (!val || val === 'undefined') {
-      // MW for now because of Apte coverage issues.
-      return 'mw';
-    }
-    return val;
-  },
-  set dictVersion(value) {
-    localStorage.setItem('dict-version', value);
   },
 };
 
@@ -107,166 +74,6 @@ function transliterateHTMLString(s, outputScript) {
   return $div.innerHTML;
 }
 
-// Sidebar show/hide
-
-const Sidebar = {
-  toggle() {
-    const classes = $('#sidebar').classList;
-    classes.toggle('block');
-    classes.toggle('hidden');
-  },
-  show() {
-    if ($('#sidebar').classList.contains('hidden')) {
-      this.toggle();
-    }
-  },
-  hide() {
-    if (!$('#sidebar').classList.contains('hidden')) {
-      this.toggle();
-    }
-  },
-  setCurrentWord(form, lemma, parse) {
-    const niceForm = Sanscript.t(form, 'slp1', Preferences.contentScript);
-    const niceLemma = Sanscript.t(lemma, 'slp1', Preferences.contentScript);
-    const html = `
-    <header>
-      <h1 class="text-xl" lang="sa">${niceForm}</h1>
-      <p class="mb-8"><span lang="sa">${niceLemma}</span> ${parse}</p>
-    </header>`;
-    $('#parse--response').innerHTML = html;
-  },
-  transliterate(from, to) {
-    const $content = $('#sidebar');
-    if ($content) {
-      transliterateElement($content, from, to);
-    }
-  },
-};
-
-// Dictionary
-
-const Dictionary = (() => {
-  function fetch(version, query, callback) {
-    $('#dict--form input[name=q]').value = query;
-
-    const url = Routes.ajaxDictionaryQuery(version, query);
-    const $container = $('#dict--response');
-    Server.getText(
-      url,
-      (resp) => {
-        $container.innerHTML = transliterateHTMLString(resp, Preferences.contentScript);
-        if (callback) {
-          callback();
-        }
-      },
-      () => {
-        $container.innerHTML = '<p>Sorry, this content is not available right now.</p>';
-      },
-    );
-  }
-
-  // Submit the form using the current form state.
-  function submitForm() {
-    const $form = $('#dict--form');
-    const query = $form.querySelector('input[name=q]').value;
-    const version = $form.querySelector('select[name=version]').value;
-
-    if (!query) {
-      return;
-    }
-
-    fetch(version, query, () => {
-      // FIXME: remove "startsWith" hack and move this to Dictionaries page.
-      if (window.location.pathname.startsWith('/tools/dict')) {
-        window.history.replaceState({}, '', Routes.dictionaryQuery(version, query));
-      }
-    });
-  }
-
-  function init() {
-    const $dictForm = $('#dict--form');
-    if ($dictForm) {
-      $dictForm.addEventListener('submit', (e) => {
-        e.preventDefault();
-        submitForm();
-      });
-
-      const $dictVersion = $('#dict--version');
-      $dictVersion.addEventListener('change', (e) => {
-        Preferences.dictVersion = e.target.value;
-        submitForm();
-      });
-      $dictVersion.value = Preferences.dictVersion;
-    }
-  }
-
-  return { init, fetch };
-})();
-
-const ParseLayer = (() => {
-  function getBlockSlug(blockID) {
-    // Slice to remove text XML id.
-    return blockID.split('.').slice(1).join('.');
-  }
-
-  function showParsedBlock(blockID) {
-    const blockSlug = getBlockSlug(blockID);
-    const $container = $('#parse--response');
-    const textSlug = Routes.getTextSlug();
-
-    const $block = $(`#${blockID.replaceAll('.', '\\.')}`);
-
-    if ($block.classList.contains('has-parsed')) {
-      // Text has already been parsed. Show it if necessary.
-      $block.classList.add('show-parsed');
-      return;
-    }
-    $block.classList.add('has-parsed');
-
-    // Fetch parsed data.
-    const url = Routes.parseData(textSlug, blockSlug);
-    Server.getText(
-      url,
-      (resp) => {
-        const parsedNode = document.createElement('div');
-        parsedNode.classList.add('parsed');
-        parsedNode.innerHTML = transliterateSanskritBlob(resp, Preferences.contentScript);
-        $block.appendChild(parsedNode);
-
-        const link = document.createElement('a');
-        link.className = 'text-sm text-zinc-400 hover:underline js--source';
-        link.href = '#';
-        link.innerHTML = '<span class=\'shown-side-by-side\'>Hide</span><span class=\'hidden-side-by-side\'>Show original</span>';
-        parsedNode.firstChild.appendChild(link);
-
-        $block.classList.add('show-parsed');
-      },
-      () => {
-        $block.classList.remove('has-parsed');
-        $container.innerHTML = '<p>Sorry, this content is not available right now. (Server error)</p>';
-        Sidebar.show();
-      },
-    );
-  }
-
-  function init() {
-    const $container = $('#parse--response');
-    if ($container) {
-      $container.addEventListener('click', (e) => {
-        e.preventDefault();
-        const link = e.target.closest('a');
-
-        const $form = $('#dict--form');
-        const query = link.textContent.trim();
-        const version = $form.querySelector('select[name=version]').value;
-        Dictionary.fetch(version, query);
-      });
-    }
-  }
-
-  return { init, showParsedBlock, getBlockSlug };
-})();
-
 const HamburgerButton = (() => {
   function init() {
     const $ham = $('#hamburger');
@@ -282,8 +89,5 @@ const HamburgerButton = (() => {
 })();
 
 (() => {
-  // Dictionary.init();
-  ParseLayer.init();
-
   HamburgerButton.init();
 })();

--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -282,7 +282,7 @@ const HamburgerButton = (() => {
 })();
 
 (() => {
-  Dictionary.init();
+  // Dictionary.init();
   ParseLayer.init();
 
   HamburgerButton.init();

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -1,5 +1,206 @@
-/* global transliterateElement, Sidebar, Preferences, Alpine, ParseLayer,
-   Sanscript, $, Dictionary */
+/* global transliterateElement, transliterateHTMLString, transliterateSanskritBlob,
+ Alpine, Sanscript, $, Routes, Server */
+
+/* Legacy code
+ * ===========
+ * Future PRs will migrate this code to Alpine.
+ */
+
+const Preferences = {
+  // FIXME: remove this once everything has been migrated to `reader.js`.
+  get contentScript() {
+    const ls = localStorage.getItem('user-script');
+    if (!ls || ls === 'undefined') {
+      return 'devanagari';
+    }
+    return ls;
+  },
+  set contentScript(value) {
+    if (value) {
+      localStorage.setItem('user-script', value);
+    }
+  },
+
+  get dictVersion() {
+    const val = localStorage.getItem('dict-version');
+    if (!val || val === 'undefined') {
+      // MW for now because of Apte coverage issues.
+      return 'mw';
+    }
+    return val;
+  },
+  set dictVersion(value) {
+    localStorage.setItem('dict-version', value);
+  },
+};
+
+const Sidebar = {
+  toggle() {
+    const classes = $('#sidebar').classList;
+    classes.toggle('block');
+    classes.toggle('hidden');
+  },
+  show() {
+    if ($('#sidebar').classList.contains('hidden')) {
+      this.toggle();
+    }
+  },
+  hide() {
+    if (!$('#sidebar').classList.contains('hidden')) {
+      this.toggle();
+    }
+  },
+  setCurrentWord(form, lemma, parse) {
+    const niceForm = Sanscript.t(form, 'slp1', Preferences.contentScript);
+    const niceLemma = Sanscript.t(lemma, 'slp1', Preferences.contentScript);
+    const html = `
+    <header>
+      <h1 class="text-xl" lang="sa">${niceForm}</h1>
+      <p class="mb-8"><span lang="sa">${niceLemma}</span> ${parse}</p>
+    </header>`;
+    $('#parse--response').innerHTML = html;
+  },
+  transliterate(from, to) {
+    const $content = $('#sidebar');
+    if ($content) {
+      transliterateElement($content, from, to);
+    }
+  },
+};
+
+// Dictionary
+
+const Dictionary = (() => {
+  function fetch(version, query, callback) {
+    $('#dict--form input[name=q]').value = query;
+
+    const url = Routes.ajaxDictionaryQuery(version, query);
+    const $container = $('#dict--response');
+    Server.getText(
+      url,
+      (resp) => {
+        $container.innerHTML = transliterateHTMLString(resp, Preferences.contentScript);
+        if (callback) {
+          callback();
+        }
+      },
+      () => {
+        $container.innerHTML = '<p>Sorry, this content is not available right now.</p>';
+      },
+    );
+  }
+
+  // Submit the form using the current form state.
+  function submitForm() {
+    const $form = $('#dict--form');
+    const query = $form.querySelector('input[name=q]').value;
+    const version = $form.querySelector('select[name=version]').value;
+
+    if (!query) {
+      return;
+    }
+
+    fetch(version, query, () => {
+      // FIXME: remove "startsWith" hack and move this to Dictionaries page.
+      if (window.location.pathname.startsWith('/tools/dict')) {
+        window.history.replaceState({}, '', Routes.dictionaryQuery(version, query));
+      }
+    });
+  }
+
+  function init() {
+    const $dictForm = $('#dict--form');
+    if ($dictForm) {
+      $dictForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        submitForm();
+      });
+
+      const $dictVersion = $('#dict--version');
+      $dictVersion.addEventListener('change', (e) => {
+        Preferences.dictVersion = e.target.value;
+        submitForm();
+      });
+      $dictVersion.value = Preferences.dictVersion;
+    }
+  }
+
+  return { init, fetch };
+})();
+
+const ParseLayer = (() => {
+  function getBlockSlug(blockID) {
+    // Slice to remove text XML id.
+    return blockID.split('.').slice(1).join('.');
+  }
+
+  function showParsedBlock(blockID) {
+    const blockSlug = getBlockSlug(blockID);
+    const $container = $('#parse--response');
+    const textSlug = Routes.getTextSlug();
+
+    const $block = $(`#${blockID.replaceAll('.', '\\.')}`);
+
+    if ($block.classList.contains('has-parsed')) {
+      // Text has already been parsed. Show it if necessary.
+      $block.classList.add('show-parsed');
+      return;
+    }
+    $block.classList.add('has-parsed');
+
+    // Fetch parsed data.
+    const url = Routes.parseData(textSlug, blockSlug);
+    Server.getText(
+      url,
+      (resp) => {
+        const parsedNode = document.createElement('div');
+        parsedNode.classList.add('parsed');
+        parsedNode.innerHTML = transliterateSanskritBlob(resp, Preferences.contentScript);
+        $block.appendChild(parsedNode);
+
+        const link = document.createElement('a');
+        link.className = 'text-sm text-zinc-400 hover:underline js--source';
+        link.href = '#';
+        link.innerHTML = '<span class=\'shown-side-by-side\'>Hide</span><span class=\'hidden-side-by-side\'>Show original</span>';
+        parsedNode.firstChild.appendChild(link);
+
+        $block.classList.add('show-parsed');
+      },
+      () => {
+        $block.classList.remove('has-parsed');
+        $container.innerHTML = '<p>Sorry, this content is not available right now. (Server error)</p>';
+        Sidebar.show();
+      },
+    );
+  }
+
+  function init() {
+    const $container = $('#parse--response');
+    if ($container) {
+      $container.addEventListener('click', (e) => {
+        e.preventDefault();
+        const link = e.target.closest('a');
+
+        const $form = $('#dict--form');
+        const query = link.textContent.trim();
+        const version = $form.querySelector('select[name=version]').value;
+        Dictionary.fetch(version, query);
+      });
+    }
+  }
+
+  return { init, showParsedBlock, getBlockSlug };
+})();
+
+(() => {
+  Dictionary.init();
+  ParseLayer.init();
+})();
+
+/* Alpine code
+ * ===========
+ * Future PRs will merge the legacy code above into the application below.
+ */
 
 function switchScript(oldScript, newScript) {
   const $textContent = $('#text--content');

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -1,5 +1,5 @@
 /* global transliterateElement, Sidebar, Preferences, Alpine, ParseLayer,
-   Sanscript, Dictionary, $ */
+   Sanscript, $, Dictionary */
 
 function switchScript(oldScript, newScript) {
   const $textContent = $('#text--content');

--- a/ambuda/templates/dictionaries/index.html
+++ b/ambuda/templates/dictionaries/index.html
@@ -1,25 +1,52 @@
 {% extends 'base-text.html' %}
 {% import 'macros/dictionaries.html' as m %}
 
+
 {% block title %}Dictionaries | Ambuda{% endblock %}
+
 
 {% block meta_description -%}
 Our fast and simple dictionary toor supports six popular dictionaries in three
 different languages.
 {%- endblock %}
 
+
 {% block content %}
+<script defer src="/static/js/main.js?v=4"></script>
+<script defer src="/static/js/dictionary.js?v=1"></script>
+<script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
+
 <h1 class="text-xl font-bold my-4">Dictionary lookup</h1>
 
-<form id="dict--form" class="mb-4">
+<form
+    id="dict--form"
+    class="mb-4"
+    x-data="dictionary"
+    x-init="init"
+    @submit.prevent="searchDictionary">
   <div class="flex mb-2">
-    <input name="q" type="text" placeholder="राम, ರಾಮ, rāma, rAma, ..." class="p-2 flex-1 bg-zinc-100 rounded-tl rounded-bl">
+    <input
+        name="q"
+        type="text"
+        placeholder="राम, ರಾಮ, rāma, rAma, ..."
+        class="p-2 flex-1 bg-zinc-100 rounded-tl rounded-bl"
+        x-model="query"
+    >
+    </input>
     <input type="submit" value="Search" class="bg-zinc-800 text-white p-2 rounded-tr rounded-br"></input>
   </div>
-  <select id="dict--version" name="version" class="text-sm bg-zinc-100 text-zinc-400 hover:text-zinc-800 p-1">
+  <select
+      id="dict--version"
+      name="version"
+      class="text-sm bg-zinc-100
+      text-zinc-400 hover:text-zinc-800 p-1"
+      @change="setSource($event.target.value)">
     {% include "include/dict-options.html" %}
   </select>
-  <select id="dict--script" class="text-sm bg-zinc-100 text-zinc-400 hover:text-zinc-800 p-1">
+  <select
+      id="dict--script"
+      class="text-sm bg-zinc-100 text-zinc-400 hover:text-zinc-800 p-1"
+      @change="setScript($event.target.value)">
     {% include 'include/script-options.html' %}
   </select>
 </form>
@@ -33,18 +60,5 @@ different languages.
   {% include 'include/dictionary-help.html' %}
 {% endif %}
 </div>
-
-<script type="text/javascript">
-document.addEventListener('DOMContentLoaded', function() {
-  const $dictScript = $('#dict--script');
-  $dictScript.addEventListener('change', (e) => {
-    const oldScript = Preferences.contentScript;
-    Preferences.contentScript = e.target.value;
-    transliterateElement($('#dict--response'), oldScript, e.target.value);
-  });
-  transliterateElement($('#dict--response'), 'devanagari', Preferences.contentScript);
-  $dictScript.value = Preferences.contentScript;
-});
-</script>
 
 {% endblock %}

--- a/ambuda/templates/dictionaries/index.html
+++ b/ambuda/templates/dictionaries/index.html
@@ -12,7 +12,7 @@ different languages.
 
 
 {% block content %}
-<script defer src="/static/js/main.js?v=4"></script>
+<script defer src="/static/js/main.js?v=5"></script>
 <script defer src="/static/js/dictionary.js?v=1"></script>
 <script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
 

--- a/ambuda/templates/header-main-footer.html
+++ b/ambuda/templates/header-main-footer.html
@@ -5,7 +5,6 @@
 {% block scripts %}
     <script async defer data-domain="ambuda.org" src="https://plausible.io/js/plausible.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/@indic-transliteration/sanscript@1.2.7/sanscript.min.js"></script>
-    <script defer src="/static/js/main.js?v=4"></script>
 {% endblock %}
 
 

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -124,12 +124,15 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
       <button class="block text-2xl p-2" onclick="Sidebar.hide()">&times;</button>
       <div id="parse--response" class="text-sm"></div>
 
-      <form id="dict--form" class="mb-4">
+      <form id="dict--form" class="mb-4" @submit.prevent="searchDictionary">
         <div class="flex mb-2 hidden lg:block">
-          <input name="q" type="text" placeholder="राम, ರಾಮ, ma, rAma, ..." class="p-2 flex-1 bg-zinc-100 rounded-tl rounded-bl"></input>
-          <input type="submit" value="Search" class="bg-zinc-800 text-white p-2 rounded-tr rounded-br"></input>
+          <input name="q" type="text" placeholder="राम, ರಾಮ, ma, rAma, ..."
+          class="p-2 flex-1 bg-zinc-100 rounded-tl rounded-bl"></input>
+          <input type="submit" value="Search"
+          class="bg-zinc-800 text-white p-2 rounded-tr rounded-br"></input>
         </div>
-        <select id="dict--version" name="version" class="text-sm bg-white lg:bg-zinc-100 text-zinc-400 hover:text-zinc-800 p-1">
+        <select id="dict--version" name="version"
+            class="text-sm bg-white lg:bg-zinc-100 text-zinc-400 hover:text-zinc-800 p-1">
           {% include "include/dict-options.html" %}
         </select>
       </form>

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -152,6 +152,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 
 
 {% block main %}
+<script defer src="/static/js/main.js?v=4"></script>
 <script defer src="/static/js/reader.js?v=4"></script>
 <script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
 

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -155,7 +155,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 
 
 {% block main %}
-<script defer src="/static/js/main.js?v=4"></script>
+<script defer src="/static/js/main.js?v=5"></script>
 <script defer src="/static/js/reader.js?v=4"></script>
 <script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
 


### PR DESCRIPTION
We now have three applications:

- `dictionary.js`, which implements the standalone dictionary tool.
- `proofreading.js`, which implements the proofing UI.
- `reader.js`, which implements the reading UI. The migration here is in
  progress; much of the code still uses vanilla JS.

We also have some core utilities in `main.js`.

Future PRs will set up a proper build system, add unit tests, and
further clean up `reader.js`.

Test plan: experimented with all three interfaces on the dev
environment.