### PR TITLE
Add basic TypeScript setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 
 # Seed the database with just enough data for the devserver to be interesting.
-db_seed_basic:
+db-seed-basic:
 	python -m ambuda.seed.lookup.role
 	python -m ambuda.seed.lookup.page_status
 	python -m ambuda.seed.texts.gretil
@@ -22,7 +22,7 @@ db_seed_basic:
 
 # Seed the database with all of the text, parse, and dictionary data we serve
 # in production.
-db_seed_all:
+db-seed-all:
 	python -m ambuda.seed.lookup.role
 	python -m ambuda.seed.lookup.page_status
 	python -m ambuda.seed.texts.gretil
@@ -37,36 +37,23 @@ db_seed_all:
 	python -m ambuda.seed.dictionaries.vacaspatyam
 
 
-# Development commands
+# Common development commands
 # ===============================================
 
 # Run the devserver, and live reload our CSS and JS.
 devserver:
-	npx concurrently "flask run" "make tailwind_watcher" "npm run build-js-dev"
-
-
-# Run Tailwind to build our CSS, and rebuild our CSS every time a relevant file
-# changes.
-tailwind_watcher:
-	npx tailwindcss -i ./ambuda/static/css/style.css -o ./ambuda/static/gen/style.css --watch
-
+	npx concurrently "flask run" "make css-dev" "make js-dev"
 
 # Run a local Celery instance for background tasks.
 celery:
 	celery -A ambuda.tasks worker --loglevel=INFO
 
-
-# Lint our JavaScript code.
-eslint:
-	npx eslint --fix ambuda/static/js/*.js
-
-
 # Lint our Python and JavaScript code.
-lint: eslint
+lint: js-lint
 	black .
 
 # Lint our Python and JavaScript code. Fail on any issues.
-lint-check: eslint
+lint-check: js-lint
 	black . --diff
 
 # Run all Python unit tests.
@@ -78,8 +65,42 @@ test:
 coverage:
 	pytest --cov=ambuda --cov-report=html test/
 
-
 # Generate Ambuda's technical documentation.
 # After the command completes, open "docs/_build/index.html".
 docs:
 	cd docs && make html
+
+
+# CSS commands
+# ===============================================
+
+# Run Tailwind to build our CSS, and rebuild our CSS every time a relevant file
+# changes.
+css-dev:
+	npx tailwindcss -i ./ambuda/static/css/style.css -o ./ambuda/static/gen/style.css --watch
+
+# Build CSS for production.
+css-prod:
+	npx tailwindcss -i ./ambuda/static/css/style.css -o ./ambuda/static/gen/style.css --minify
+
+
+# JavaScript commands
+# ===============================================
+
+# Run esbuild to build our JavaScript, and rebuild our JavaScript every time a
+# relevant file changes.
+js-dev:
+	npx esbuild ambuda/static/js/main.js --outfile=ambuda/static/gen/main.js --bundle --watch
+
+# Build JS for production.
+js-prod:
+	npx esbuild ambuda/static/js/main.js --outfile=ambuda/static/gen/main.js --bundle --minify
+
+# Lint our JavaScript code.
+# FIXME(arun): typescript lint
+js-lint:
+	npx eslint --fix ambuda/static/js/*.js
+
+# Check our JavaScript code for type consistency.
+js-check-types:
+	npx tsc ambuda/static/js/*.ts -noEmit

--- a/ambuda/static/js/core.ts
+++ b/ambuda/static/js/core.ts
@@ -34,14 +34,14 @@ function forEachTextNode(elem, callback) {
   }
 }
 
-function transliterateElement($el, from, to) {
+function transliterateElement($el, from: string, to: string) {
   $el.querySelectorAll('[lang=sa]').forEach((elem) => {
     forEachTextNode(elem, (s) => Sanscript.t(s, from, to));
   });
 }
 
 // Transliterate mixed Sanskrit content.
-function transliterateSanskritBlob(blob, outputScript) {
+function transliterateSanskritBlob(blob: string, outputScript: string) {
   const $div = document.createElement('div');
   $div.innerHTML = blob;
   $div.querySelectorAll('*').forEach((elem) => {
@@ -51,7 +51,7 @@ function transliterateSanskritBlob(blob, outputScript) {
 }
 
 // Transliterate mixed English/Sanskrit content.
-function transliterateHTMLString(s, outputScript) {
+function transliterateHTMLString(s: string, outputScript: string) {
   const $div = document.createElement('div');
   $div.innerHTML = s;
   transliterateElement($div, 'devanagari', outputScript);

--- a/ambuda/static/js/dictionary.js
+++ b/ambuda/static/js/dictionary.js
@@ -2,7 +2,7 @@
 
 import {
   transliterateElement, transliterateHTMLString, $, Server,
-} from './core';
+} from './core.ts';
 import Routes from './routes';
 
 const DICTIONARY_CONFIG_KEY = 'dictionary';

--- a/ambuda/static/js/hamburger-button.js
+++ b/ambuda/static/js/hamburger-button.js
@@ -1,4 +1,4 @@
-import { $ } from './core';
+import { $ } from './core.ts';
 
 export default (() => {
   function init() {

--- a/ambuda/static/js/proofer.js
+++ b/ambuda/static/js/proofer.js
@@ -1,7 +1,7 @@
 /* global Alpine, $, OpenSeadragon, IMAGE_URL */
 /* Transcription and proofreading interface. */
 
-import { $ } from './core';
+import { $ } from './core.ts';
 
 const CONFIG_KEY = 'proofing-editor';
 const LAYOUT_SIDE_BY_SIDE = 'flex flex-col-reverse md:flex-row h-[90vh]';

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -2,7 +2,7 @@
 
 import {
   transliterateElement, transliterateHTMLString, transliterateSanskritBlob, $, Server,
-} from './core';
+} from './core.ts';
 import Routes from './routes';
 
 /* Legacy code
@@ -196,11 +196,6 @@ const ParseLayer = (() => {
   return { init, showParsedBlock, getBlockSlug };
 })();
 
-(() => {
-  Dictionary.init();
-  ParseLayer.init();
-})();
-
 /* Alpine code
  * ===========
  * Future PRs will merge the legacy code above into the application below.
@@ -224,6 +219,10 @@ export default () => ({
   init() {
     this.loadSettings();
     switchScript('devanagari', this.script);
+
+    // Load legacy content.
+    Dictionary.init();
+    ParseLayer.init();
   },
   loadSettings() {
     const settingsStr = localStorage.getItem(READER_CONFIG_KEY);

--- a/ambuda/static/js/sanscript.d.ts
+++ b/ambuda/static/js/sanscript.d.ts
@@ -1,0 +1,3 @@
+declare namespace Sanscript {
+  function t(text: string, input: string, output: string): string;
+}

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -159,7 +159,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
   <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1">
   <div :class="fontSize">
-  <div :class="parseLayout">
+  <div :class="parseLayout" lang="sa">
     {{ header() }}
     {% for block_ in html_blocks %}
     <s-block id="{{ block_.id }}">

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,11 +80,11 @@ scripts** that fetch the data we need from the Internet.
 Running all of the Ambuda seed scripts can be quite slow. For basic dev tasks,
 we recomemnd running just a basic subset of them::
 
-    make db_seed_basic
+    make db-seed-basic
 
 If you want to install everything and are willing to wait, you can run::
 
-    make db_seed_all
+    make db-seed-all
 
 .. note::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,7 @@ After you've cloned the repo, you can bring up a minimal setup by running the
 following::
 
     make install
-    make db_seed_basic
+    make db-seed-basic
     make devserver
 
 Then go to `localhost:5000` to see the local application.

--- a/fabfile.py
+++ b/fabfile.py
@@ -70,17 +70,10 @@ def deploy_to_commit(_, pointer: str):
         with c.prefix("source env/bin/activate"):
             c.run("pip install -r requirements.txt")
 
-        # Build production CSS with Tailwind.
+        # Build production frontend assets.
         c.run("npm install")
-        c.run(
-            (
-                "npx tailwindcss -i ./ambuda/static/css/style.css "
-                "-o ambuda/static/gen/style.css --minify"
-            )
-        )
-
-        # Build production JS with Esbuild
-        c.run("npm run build-js-prod")
+        c.run("make css-prod")
+        c.run("make js-prod")
 
         # Verify that unit tests pass on prod.
         with c.prefix("source env/bin/activate"):

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "dependencies": {
         "esbuild": "^0.15.5",
         "postcss": "^8.4.14",
-        "tailwindcss": "^3.0.24"
+        "tailwindcss": "^3.0.24",
+        "typescript": "^4.7.4"
       },
       "devDependencies": {
         "concurrently": "^7.3.0",
@@ -2773,6 +2774,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -4801,6 +4814,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
-  "scripts": {
-    "build-js-prod": "esbuild ambuda/static/js/main.js --outfile=ambuda/static/gen/main.js --bundle --minify",
-    "build-js-dev": "esbuild ambuda/static/js/main.js --outfile=ambuda/static/gen/main.js --bundle --watch"
-  },
   "dependencies": {
     "esbuild": "^0.15.5",
     "postcss": "^8.4.14",
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.0.24",
+    "typescript": "^4.7.4"
   },
   "devDependencies": {
     "concurrently": "^7.3.0",

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -75,10 +75,10 @@ the following commands:
 To add data to the database, try either of the commands below:
 
     # A smaller install with some missing data
-    make db_seed_basic
+    make db-seed-basic
 
     # A full install that's larger and slower
-    make db_seed_all
+    make db-seed-all
 
 For help, join our Discord: https://discord.gg/7rGdTyWY7Z
 


### PR DESCRIPTION
Now we can run `make js_check_types` to type check our frontend code.

In addition, standardize our naming conventions for `make` commands and
fix a few small frontend regressions.