### PR TITLE
Build docs on CI

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Lint
         run: make lint-check
   
+      - name: Build docs
+        run: make docs
+
   run-tests:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This will make sure we don't accidentally break readthedocs builds with a docs update.