### PR TITLE
Set up CSP, unpkg -> jsdelivr

### DIFF
--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -119,4 +119,9 @@ def create_app(config_env: str):
         }
     )
 
+    @app.after_request
+    def add_security_headers(resp):
+        resp.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.google.com https://www.gstatic.com https://plausible.io; frame-src https://www.google.com;"
+        return resp
+
     return app

--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -121,7 +121,9 @@ def create_app(config_env: str):
 
     @app.after_request
     def add_security_headers(resp):
-        resp.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.google.com https://www.gstatic.com https://plausible.io; frame-src https://www.google.com;"
+        resp.headers[
+            "Content-Security-Policy"
+        ] = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.google.com https://www.gstatic.com https://plausible.io; frame-src https://www.google.com; img-src 'self' data:;"
         return resp
 
     return app

--- a/ambuda/templates/base.html
+++ b/ambuda/templates/base.html
@@ -7,7 +7,7 @@
     A breakthrough Sanskrit library. Read our library of traditional Sanskrit texts with word-by-word analysis, integrated dictionary support, and so much more.
     {%- endblock %}">
     <link rel="stylesheet" type="text/css" href="/static/gen/style.css?v=10">
-    <link rel="icon" href="data:,">
+    <!-- <link rel="icon" href="data:,"> -->
     <title>{% block title %}{% endblock %}</title>
     {% block scripts %}{% endblock %}
   </head>

--- a/ambuda/templates/base.html
+++ b/ambuda/templates/base.html
@@ -7,7 +7,7 @@
     A breakthrough Sanskrit library. Read our library of traditional Sanskrit texts with word-by-word analysis, integrated dictionary support, and so much more.
     {%- endblock %}">
     <link rel="stylesheet" type="text/css" href="/static/gen/style.css?v=10">
-    <!-- <link rel="icon" href="data:,"> -->
+    <link rel="icon" href="data:,">
     <title>{% block title %}{% endblock %}</title>
     {% block scripts %}{% endblock %}
   </head>

--- a/ambuda/templates/header-main-footer.html
+++ b/ambuda/templates/header-main-footer.html
@@ -7,7 +7,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/@indic-transliteration/sanscript@1.2.7/sanscript.min.js"></script>
     {# Load scripts before Alpine so that our init hooks are properly set up. #}
     <script defer src="/static/gen/main.js"></script>
-    <script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
 {% endblock %}
 
 


### PR DESCRIPTION
As I was writing up a privacy policy in https://github.com/ambuda-org/ambuda/pull/169, I noticed a few things:
- unpkg doesn't have a privacy policy (see https://twitter.com/unpkg/status/1215718511537876992)
- we probably want to avoid loading as many third-party scripts as possible, for privacy reasons

So I switched from unpkg -> jsdelivr for the alpine script, and I also set up a CSP header that whitelists domains whose scripts can be loaded on our site. This also has the added bonus that inline javascript is disallowed by CSP, helping mitigate the risks of XSS attacks.

We'd probably eventually want to cut down on the number of external scripts and just get to `script-src 'self'` if possible, though.