### PR TITLE
Fix various UI regressions

### DIFF
--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -243,7 +243,7 @@ export default () => ({
     this.loadSettings();
     switchScript('devanagari', this.script);
 
-    // Sync UI with application state.
+    // Sync UI with application state. See comments on `uiScript` for details.
     this.uiScript = this.script;
 
     // Load legacy content.
@@ -280,16 +280,9 @@ export default () => ({
     localStorage.setItem(READER_CONFIG_KEY, JSON.stringify(settings));
   },
 
-  setFontSize(value) {
-    this.fontSize = value;
-    this.saveSettings();
-  },
   setScript() {
     switchScript(this.script, this.uiScript);
     this.script = this.uiScript;
-    this.saveSettings();
-  },
-  setParseLayout() {
     this.saveSettings();
   },
 

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -54,7 +54,7 @@ or in their own modal window. #}
 {% macro settings() %}
   <div class="hidden md:inline text-sm border-r px-4">
     <span>Font Size:</span>
-    <select class="p-1" x-model="fontSize" @change="setFontSize">
+    <select class="p-1" x-model="fontSize" @change="saveSettings">
       <option value="md:text-base">Tiny</option>
       <option value="md:text-lg">Small</option>
       <option value="md:text-xl" selected>Medium</option>
@@ -71,7 +71,7 @@ or in their own modal window. #}
   {% if not has_no_parse %}
   <div class="hidden md:inline text-sm border-r px-4">
     <span>Parsed View:</span>
-    <select id="switch-parse-options" class="p-1" x-model="parseLayout" @change="setParseLayout">
+    <select id="switch-parse-options" class="p-1" x-model="parseLayout" @change="saveSettings">
       <option value="in-place" selected>In place</option>
       <option value="side-by-side">Side by side</option>
     </select>

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -54,7 +54,7 @@ or in their own modal window. #}
 {% macro settings() %}
   <div class="hidden md:inline text-sm border-r px-4">
     <span>Font Size:</span>
-    <select class="p-1" @change="setFontSize($event.target.value)">
+    <select class="p-1" x-model="fontSize" @change="setFontSize">
       <option value="md:text-base">Tiny</option>
       <option value="md:text-lg">Small</option>
       <option value="md:text-xl" selected>Medium</option>
@@ -64,14 +64,14 @@ or in their own modal window. #}
   </div>
   <div class="text-sm border-r px-4">
     <span class="hidden md:inline">Script:</span>
-    <select id="switch-sa" class="p-1" @change="setScript($event.target.value)">
+    <select id="switch-sa" class="p-1" @change="setScript" x-model="uiScript">
       {% include 'include/script-options.html' %}
     </select>
   </div>
   {% if not has_no_parse %}
   <div class="hidden md:inline text-sm border-r px-4">
     <span>Parsed View:</span>
-    <select id="switch-parse-options" class="p-1" @change="setParseLayout($event.target.value)">
+    <select id="switch-parse-options" class="p-1" x-model="parseLayout" @change="setParseLayout">
       <option value="in-place" selected>In place</option>
       <option value="side-by-side">Side by side</option>
     </select>
@@ -166,10 +166,11 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
       <div class="mula">{{ block_.html|safe }}</div>
     </s-block>
     {% endfor %}
-    {{ footer() }}
   </div>
   </div>
   </div>
+
+  {{ footer() }}
   {{ sidebar() }}
 </article>
 {% endblock %}


### PR DESCRIPTION
Fixes the following:

- Script menu always reverts to Devanagari (#181). This also affects
  the text size dropdown and the parse layout dropdown.
- Transliteration also affects UI elements (#182).

Remaining regressions that still need fixing:

- Side-by-side layout is broken (#173). This is due to some CSS changes
  in a parent element.

Test plan:

Manual testing. But now that our frontend application code is more
complex, it's time to add more robust testing tools for it. I'll do this
in a follow-up PR.