### PR TITLE
Add secret key and JS build to install script

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2,6 +2,7 @@
 
 import click
 import getpass
+from slugify import slugify
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
@@ -62,11 +63,12 @@ def add_role(username: str, role: str):
         u.roles.append(r)
         session.add(u)
         session.commit()
-    print(f'Added role "{role}" to user "{user}".')
+    print(f'Added role "{role}" to user "{username}".')
 
 
 @cli.command()
-def create_test_project():
+@click.argument("title")
+def create_test_project(title):
     """Create a test proofing project with 100 pages."""
     current_app = ambuda.create_app("development")
     with current_app.app_context():
@@ -79,10 +81,9 @@ def create_test_project():
                 "Please create a user first with `create-user`."
             )
 
-        q.create_project(
-            title="Test project", slug="test-project", creator_id=arbitrary_user.id
-        )
-        project = q.project("test-project")
+        slug = slugify(title)
+        q.create_project(title=title, slug=slug, creator_id=arbitrary_user.id)
+        project = q.project(slug)
 
         default_status = session.query(db.PageStatus).filter_by(name="reviewed-0").one()
         for i in range(1, 101):
@@ -94,7 +95,7 @@ def create_test_project():
             )
             session.add(page)
         session.commit()
-    print(f'Created project "test-project".')
+    print(f'Created project "{title}" with slug "{slug}".')
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -35,6 +35,11 @@ PRODUCTION = "production"
 
 
 def _make_path(path: Path):
+    """Create a path if it doesn't exist already.
+
+    If possible, avoid using this function so that our config code has fewer
+    side effects. Currently, we use this function only to set up unit tests.
+    """
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -42,7 +47,8 @@ def _make_path(path: Path):
 def _env(key: str, default=None) -> Optional[str]:
     """Fetch a value from the local environment.
 
-    :param key: the envvar to fetch
+    :param key: the environment variable to fetch
+    :return: a value, or ``None`` if the variable is undefined.
     """
     return os.environ.get(key, default)
 

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -15,8 +15,8 @@ rm -Rf env/ node_modules/
 # Install Node dependencies.
 npm install
 
-# Build initial Tailwind CSS
-npx tailwindcss -i ./ambuda/static/css/style.css -o ambuda/static/gen/style.css --minify
+# Build initial CSS and JavaScript.
+make css-prod js-prod
 
 
 # Python dependencies
@@ -38,6 +38,7 @@ cat << EOF > .env
 
 FLASK_ENV=development
 FLASK_UPLOAD_FOLDER="$(pwd)/data/file-uploads"
+SECRET_KEY="insecure development secret key"
 SQLALCHEMY_DATABASE_URI="sqlite:///database.db"
 
 GOOGLE_APPLICATION_CREDENTIALS="<Google API credentials>"


### PR DESCRIPTION
- Add SECRET_KEY to the `.env` file we generate during `make install` so
  that the user doesn't have to define it manually.

- Create an initial build of our JS code both so that `flask run` works
  and also so that we adequately test out esbuild during the install
  process.

Test plan: ran these commands after deleting untracked files (`.env`,
database, `env`, `node_modules`).