### PR TITLE
Add sanity check to validate database schemas

### DIFF
--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -17,6 +17,7 @@ from sqlalchemy import exc
 import config
 from ambuda import auth as auth_manager
 from ambuda import admin as admin_manager
+from ambuda import checks
 from ambuda import database
 from ambuda import filters
 from ambuda import queries
@@ -72,6 +73,10 @@ def create_app(config_env: str):
     # different configurations.
     load_dotenv(".env")
     config_spec = config.load_config_object(config_env)
+
+    # Sanity checks
+    if config_env != config.TESTING:
+        checks.check_app_schema_matches_db_schema(config_spec.SQLALCHEMY_DATABASE_URI)
 
     # Initialize Sentry monitoring only in production so that our Sentry page
     # contains only production warnings (as opposed to dev warnings).

--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -120,4 +120,5 @@ def check_app_schema_matches_db_schema(database_uri: str):
             _warn(f"- {error}")
         sys.exit(1)
     else:
-        print("Database check OK")
+        # Style the output to match Flask's styling.
+        print(" * [OK] Ambuda database check has passed.", flush=True)

--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -2,9 +2,11 @@
 
 
 import sys
+from typing import Optional
 
 from click import style
 from sqlalchemy import create_engine
+from sqlalchemy.schema import Column
 from sqlalchemy import inspect
 
 from ambuda.models.base import Base
@@ -15,13 +17,47 @@ def _warn(text: str = ""):
     print(style(text, fg="red"))
 
 
+def _full_column_name(table_name: str, col: str) -> str:
+    return f"{table_name}.{col}"
+
+
+def _check_column(app_col: Column, db_col: dict[str, str]) -> list[str]:
+    full_name = _full_column_name(app_col.table.name, app_col.name)
+    errors = []
+
+    if app_col.nullable and not db_col["nullable"]:
+        errors.append(f'Column "{full_name}" is nullable in the app but not in the db.')
+    elif db_col["nullable"] and not app_col.nullable:
+        errors.append(f'Column "{full_name}" is nullable in the db but not in the app.')
+
+    if app_col.primary_key and not db_col["primary_key"]:
+        errors.append(
+            f'Column "{full_name}" is a primary key in the app but not in the db.'
+        )
+    elif db_col["primary_key"] and not app_col.primary_key:
+        errors.append(
+            f'Column "{full_name}" is a primary key in the db but not in the app.'
+        )
+
+    return errors
+
+
 def check_app_schema_matches_db_schema(database_uri: str):
     """Check that our application tables and database tables match.
 
     Currently, we apply the following checks:
+
     - All app tables exist in the database.
     - A given app table and its corresponding database table have the same
       column names.
+    - A given app columns and its database column have equal `nullable` and
+      `primary_key` status.
+
+    Here are some important checks that we haven't implemented yet:
+
+    - Column have equal types.
+    - Column have equal default values.
+    - Column have equal indices.
 
     If any check fails, exit gracefully and tell the user how to resolve the
     issue.
@@ -35,24 +71,34 @@ def check_app_schema_matches_db_schema(database_uri: str):
     errors = []
 
     for table_name, table in Base.metadata.tables.items():
-        app_column_names = set(table.columns.keys())
-        db_column_names = {c["name"] for c in inspector.get_columns(table_name)}
+        app_columns = table.columns
+        db_columns = {c["name"]: c for c in inspector.get_columns(table_name)}
+
+        app_column_names = set(app_columns.keys())
+        db_column_names = set(db_columns.keys())
 
         if not db_column_names:
-            errors.append(f'Table "{table_name}" found in app, missing in db')
+            errors.append(f'Table "{table_name}" found in app but missing in db.')
             continue
 
         for col in app_column_names:
             if col not in db_column_names:
-                errors.append(
-                    f'Column "{table_name}.{col}" found in app, missing in db'
-                )
+                full_name = _full_column_name(table_name, col)
+                errors.append(f'Column "{full_name}" found in app but missing in db.')
 
         for col in db_column_names:
             if col not in app_column_names:
-                errors.append(
-                    f'Column "{table_name}.{col}" found in db, missing in app'
-                )
+                full_name = _full_column_name(table_name, col)
+                errors.append(f'Column "{full_name}" found in db but missing in app.')
+
+        for col in app_column_names & db_column_names:
+            app_col = app_columns[col]
+            db_col = db_columns[col]
+            full_name = _full_column_name(table_name, col)
+
+            column_errors = _check_column(app_col, db_col)
+            if column_errors:
+                errors.extend(column_errors)
 
     if errors:
         _warn("The data tables defined in your application code don't match the")
@@ -69,6 +115,7 @@ def check_app_schema_matches_db_schema(database_uri: str):
         _warn("Ambuda Discord server (https://discord.gg/7rGdTyWY7Z).")
         _warn()
         _warn("Errors found:")
+        _warn()
         for error in errors:
             _warn(f"- {error}")
         sys.exit(1)

--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -1,0 +1,76 @@
+"""Sanity checks that run on application startup."""
+
+
+import sys
+
+from click import style
+from sqlalchemy import create_engine
+from sqlalchemy import inspect
+
+from ambuda.models.base import Base
+
+
+def _warn(text: str = ""):
+    """Print a warning message to the terminal."""
+    print(style(text, fg="red"))
+
+
+def check_app_schema_matches_db_schema(database_uri: str):
+    """Check that our application tables and database tables match.
+
+    Currently, we apply the following checks:
+    - All app tables exist in the database.
+    - A given app table and its corresponding database table have the same
+      column names.
+
+    If any check fails, exit gracefully and tell the user how to resolve the
+    issue.
+
+    :param database_uri:
+    """
+
+    engine = create_engine(database_uri)
+    inspector = inspect(engine)
+
+    errors = []
+
+    for table_name, table in Base.metadata.tables.items():
+        app_column_names = set(table.columns.keys())
+        db_column_names = {c["name"] for c in inspector.get_columns(table_name)}
+
+        if not db_column_names:
+            errors.append(f'Table "{table_name}" found in app, missing in db')
+            continue
+
+        for col in app_column_names:
+            if col not in db_column_names:
+                errors.append(
+                    f'Column "{table_name}.{col}" found in app, missing in db'
+                )
+
+        for col in db_column_names:
+            if col not in app_column_names:
+                errors.append(
+                    f'Column "{table_name}.{col}" found in db, missing in app'
+                )
+
+    if errors:
+        _warn("The data tables defined in your application code don't match the")
+        _warn("tables defined in your database. Usually, this means that you need")
+        _warn("to upgrade your database schemas. You can do so by running:")
+        _warn()
+        _warn("    alembic upgrade head")
+        _warn()
+        _warn("For more information, see our official docs at:")
+        _warn()
+        _warn("    https://ambuda.readthedocs.io/en/latest/managing-the-database.html")
+        _warn()
+        _warn("If the error persists, please ping the #backend channel on the")
+        _warn("Ambuda Discord server (https://discord.gg/7rGdTyWY7Z).")
+        _warn()
+        _warn("Errors found:")
+        for error in errors:
+            _warn(f"- {error}")
+        sys.exit(1)
+    else:
+        print("Database check OK")

--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -14,7 +14,7 @@ from ambuda.models.base import Base
 
 def _warn(text: str = ""):
     """Print a warning message to the terminal."""
-    print(style(text, fg="red"))
+    print(style(text, fg="red"), file=sys.stderr)
 
 
 def _full_column_name(table_name: str, col: str) -> str:


### PR DESCRIPTION
This sanity check verifies that the data tables defined in the
application match the data tables defined in the database. Currently,
this code checks that:

- all app tables exist in the database
- a given app table and its corresponding database table have the same
  column names.

Future PRs can add more extensive checks.

Test plan: ran the sanity check under the following conditions:

1. latest main (OK)
2. one column missing from a model (failed)
3. one model deleted (failed)