### PR TITLE
Add warning for make install on dirty repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ db-seed-all:
 	python -m ambuda.seed.dictionaries.vacaspatyam
 
 
+# Delete all application data and dependencies. This cannot be undone.
+destructive-clean:
+	rm -Rf data/ env/ node_modules/ .env database.db
+
+
 # Common development commands
 # ===============================================
 

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,6 @@ db-seed-all:
 	python -m ambuda.seed.dictionaries.vacaspatyam
 
 
-# Delete all application data and dependencies. This cannot be undone.
-destructive-clean:
-	rm -Rf data/ env/ node_modules/ .env database.db
-
-
 # Common development commands
 # ===============================================
 

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -72,9 +72,8 @@ EOF
 # Create tables
 python -m scripts.initialize_db
 
-# Add simple lookup tables, since it's easy for a user to miss these later.
-python -m ambuda.seed.lookup.page_status
-python -m ambuda.seed.lookup.role
+# Add some starter data with a few basic seed scripts.
+make db-seed-basic
 
 # Create Alembic's migrations table.
 alembic ensure_version
@@ -90,14 +89,13 @@ SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS
 
 You have successfully installed Ambuda!
 
-To add texts, parse data, and dictionaries to the database, try either of the
-commands below:
+We've added some sample data to start you off. To load all of our texts,
+dictionaries, and parse data into the development environment, you can run:
 
-    # A smaller install with some missing data
-    make db-seed-basic
-
-    # A full install that's larger and slower
     make db-seed-all
+
+(NOTE: the command above will be quite slow, since it must fetch several large
+data files from several different websites.)
 
 To create some sample data for our proofing interface, try the commands below.
 In these commands, arguments in <angle-brackets> must be supplied by you:

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -72,6 +72,10 @@ EOF
 # Create tables
 python -m scripts.initialize_db
 
+# Add simple lookup tables, since it's easy for a user to miss these later.
+python -m ambuda.seed.lookup.page_status
+python -m ambuda.seed.lookup.role
+
 # Create Alembic's migrations table.
 alembic ensure_version
 

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -3,14 +3,29 @@
 # Exit if any step in this install script fails.
 set -e
 
+if [ -f data ] || [ -f env ] || [ -f node_modules ] || [ -f .env ] || [ -f database.db ]; then
+cat << "EOF"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some of the files in your directory were created during a previous install. Our
+install script does not know how to treat these files.
+
+If you want to permanently delete these old files and install Ambuda from
+scratch, please run the following command:
+
+    make destructive-clean install
+
+EOF
+    exit 1
+fi
+
 echo "Beginning clean install of Ambuda."
 
 
-# JavaScript dependencies
-# =======================
-
-# Clean up any existing state so that we can do a clean install.
-rm -Rf env/ node_modules/
+# Frontend dependencies
+# =====================
 
 # Install Node dependencies.
 npm install

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -5,21 +5,27 @@ set -e
 
 if [ -f data ] || [ -f env ] || [ -f node_modules ] || [ -f .env ] || [ -f database.db ]; then
 cat << "EOF"
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR ERROR
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some of the files in your directory were created during a previous install. Our
-install script does not know how to treat these files.
+Some of the files in your directory were created during a previous install. To
+ensure that you have a clean install, this script will delete the following
+files and directories, if they exist:
 
-If you want to permanently delete these old files and install Ambuda from
-scratch, please run the following command:
-
-    make destructive-clean install
+- database.db
+- .env
+- data/
+- env/
+- node_modules/
 
 EOF
-    exit 1
+    python3 -c "exit(0) if input('Are you sure you want to continue? (y/n): ') == 'y' else exit(1)"
+
+    echo "Cleaning up old state ..."
+    rm -Rf .env database.db data/ env/ node_modules/
 fi
+
 
 echo "Beginning clean install of Ambuda."
 
@@ -78,8 +84,25 @@ cat << "EOF"
 SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS SUCCESS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You have successfully installed Ambuda! To start the development server, run
-the following commands:
+You have successfully installed Ambuda!
+
+To add texts, parse data, and dictionaries to the database, try either of the
+commands below:
+
+    # A smaller install with some missing data
+    make db-seed-basic
+
+    # A full install that's larger and slower
+    make db-seed-all
+
+To create some sample data for our proofing interface, try the commands below.
+In these commands, arguments in <angle-brackets> must be supplied by you:
+
+    ./cli.py create-user
+    ./cli.py add-role <username> admin
+    ./cli.py create-project <project-title> <path-to-project-pdf>
+
+To start the development server, run the following commands:
 
     # This command works on Bash. You might need to change this command for
     # other shells.
@@ -87,14 +110,6 @@ the following commands:
 
     # Run the devserver.
     make devserver
-
-To add data to the database, try either of the commands below:
-
-    # A smaller install with some missing data
-    make db-seed-basic
-
-    # A full install that's larger and slower
-    make db-seed-all
 
 For help, join our Discord: https://discord.gg/7rGdTyWY7Z
 


### PR DESCRIPTION
If `make install` detects files that indicate a previous install
attempt, abort the install and tell the user how to proceed.

Test plan: ran `make destructive-clean install` on the repo.