### PR TITLE
Use Celery project uploader in cli.py

### DIFF
--- a/ambuda/queries.py
+++ b/ambuda/queries.py
@@ -160,20 +160,6 @@ def project(slug: str) -> Optional[db.Project]:
     return session.query(db.Project).filter(db.Project.slug == slug).first()
 
 
-def create_project(*, title: str, slug: str, creator_id: int):
-    session = get_session()
-
-    board = db.Board(title=f"{slug} discussion board")
-    session.add(board)
-    session.flush()
-
-    project = db.Project(slug=slug, title=title, creator_id=creator_id)
-    project.board_id = board.id
-
-    session.add(project)
-    session.commit()
-
-
 def thread(*, id: int) -> Optional[db.Thread]:
     session = get_session()
     return session.query(db.Thread).filter_by(id=id).first()

--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -1,5 +1,6 @@
 /* globals Alpine, Sanscript */
 
+import { $, Server } from './core.ts';
 import Dictionary from './dictionary';
 import Reader from './reader';
 import Proofer from './proofer';
@@ -14,3 +15,8 @@ window.addEventListener('alpine:init', () => {
 (() => {
   HamburgerButton.init();
 })();
+
+// Export to all pages.
+// FIXME(arun): clean up existing usages.
+window.Server = Server;
+window.$ = $;

--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -16,7 +16,9 @@ window.addEventListener('alpine:init', () => {
   HamburgerButton.init();
 })();
 
-// Export to all pages.
-// FIXME(arun): clean up existing usages.
+// Export a few internal values to support some existing ad-hoc usage (e.g.,
+// in the pages that shows the progress bar for a project upload.)
+// FIXME(arun): clean up existing usage of these values so that our code is less
+// FIXME(arun): ad-hoc.
 window.Server = Server;
 window.$ = $;

--- a/ambuda/tasks/projects.py
+++ b/ambuda/tasks/projects.py
@@ -13,7 +13,30 @@ from config import create_config_only_app
 
 
 class TaskStatus:
-    """Helper class to track progress on the current task."""
+    """Helper class to track progress on a task."""
+
+    def progress(self, current: int, total: int):
+        """Update the task's progress.
+
+        :param current: progress numerator
+        :param total: progress denominator
+        """
+        raise NotImplementedError
+
+    def success(self, num_pages: int, slug: str):
+        """Mark the task as a success.
+
+        # FIXME(arun): make this API more generic.
+        """
+        raise NotImplementedError
+
+    def failure(self, message: str):
+        """Mark the task as failed."""
+        raise NotImplementedError
+
+
+class CeleryTaskStatus(TaskStatus):
+    """Helper class to track progress on a Celery task."""
 
     def __init__(self, task):
         self.task = task
@@ -39,6 +62,19 @@ class TaskStatus:
     def failure(self, message: str):
         """Mark the task as failed."""
         self.task.update_state(state=states.FAILURE, meta={"message": message})
+
+
+class LocalTaskStatus(TaskStatus):
+    """Helper class to track progress on a task running locally."""
+
+    def progress(self, current: int, total: int):
+        print(f"{current} / {total} complete")
+
+    def success(self, num_pages: int, slug: str):
+        print(f"Succeeded. Project is at {slug}.")
+
+    def failure(self, message: str):
+        print(f"Failed. ({message})")
 
 
 def _split_pdf_into_pages(
@@ -82,8 +118,8 @@ def _add_project_to_database(title: str, slug: str, num_pages: int, creator_id: 
     print(f"Fetching project and status (slug = {slug}) ...")
     unreviewed = session.query(db.PageStatus).filter_by(name="reviewed-0").one()
 
+    print(f"Creating {num_pages} Page entries (slug = {slug}) ...")
     for n in range(1, num_pages + 1):
-        print(f"Creating page {slug}: {n}")
         session.add(
             db.Page(
                 project_id=project.id,
@@ -95,21 +131,26 @@ def _add_project_to_database(title: str, slug: str, num_pages: int, creator_id: 
     session.commit()
 
 
-@app.task(bind=True)
-def create_project(
-    self,
+def _create_project_inner(
+    *,
     title: str,
     pdf_path: str,
     output_dir: str,
     app_environment: str,
     creator_id: int,
+    task_status: TaskStatus,
 ):
     """Split the given PDF into pages and register the project on the database.
+
+    We separate this function from `create_project` so that we can run this
+    function in a non-Celery context (for example, in `cli.py`).
 
     :param title: the project title.
     :param pdf_path: local path to the source PDF.
     :param output_dir: local path where page images will be stored.
     :param app_environment: the app environment, e.g. `"development"`.
+    :param creator_id: the user that created this project.
+    :param task_status: tracks progress on the task.
     """
     print(f'Received upload task "{title}" for path {pdf_path}.')
 
@@ -127,7 +168,6 @@ def create_project(
 
     pdf_path = Path(pdf_path)
     pages_dir = Path(output_dir)
-    task_status = TaskStatus(self)
 
     num_pages = _split_pdf_into_pages(Path(pdf_path), Path(pages_dir), task_status)
     with app.app_context():
@@ -139,3 +179,28 @@ def create_project(
         )
 
     task_status.success(num_pages, slug)
+
+
+@app.task(bind=True)
+def create_project(
+    self,
+    *,
+    title: str,
+    pdf_path: str,
+    output_dir: str,
+    app_environment: str,
+    creator_id: int,
+):
+    """Split the given PDF into pages and register the project on the database.
+
+    For argument details, see `_create_project_inner`.
+    """
+    task_status = CeleryTaskStatus(self)
+    _create_project_inner(
+        title=title,
+        pdf_path=pdf_path,
+        output_dir=output_dir,
+        app_environment=app_environment,
+        creator_id=creator_id,
+        task_status=task_status,
+    )

--- a/ambuda/tasks/projects.py
+++ b/ambuda/tasks/projects.py
@@ -13,7 +13,11 @@ from config import create_config_only_app
 
 
 class TaskStatus:
-    """Helper class to track progress on a task."""
+    """Helper class to track progress on a task.
+
+    - For Celery tasks, use CeleryTaskStatus.
+    - For local usage (unit tests, CLI, ...), use a LocalTaskStatus instead.
+    """
 
     def progress(self, current: int, total: int):
         """Update the task's progress.

--- a/test/ambuda/tasks/test_projects_tasks.py
+++ b/test/ambuda/tasks/test_projects_tasks.py
@@ -1,16 +1,38 @@
+import tempfile
+
+import fitz
+
 import ambuda.queries as q
 import ambuda.tasks.projects as projects
 
 
-def test_add_project_to_database(flask_app):
+def _create_sample_pdf(output_path: str, num_pages: int):
+    """Create a toy PDF with 10 pages."""
+    doc = fitz.open()
+    for i in range(1, num_pages + 1):
+        page = doc.new_page()
+        where = fitz.Point(50, 50)
+        page.insert_text(where, f"This is page {i}", fontsize=30)
+    doc.save(output_path)
+
+
+def test_create_project_inner(flask_app):
     with flask_app.app_context():
-        assert not q.project("cool")
-        projects._add_project_to_database(
+        project = q.project("cool-project")
+        assert project is None
+
+        f = tempfile.NamedTemporaryFile()
+        _create_sample_pdf(f.name, num_pages=10)
+
+        projects._create_project_inner(
             title="Cool project",
-            slug="cool",
-            num_pages=100,
+            pdf_path=f.name,
+            output_dir=flask_app.config["UPLOAD_FOLDER"],
+            app_environment=flask_app.config["AMBUDA_ENVIRONMENT"],
             creator_id=1,
+            task_status=projects.LocalTaskStatus(),
         )
-        project = q.project("cool")
+
+        project = q.project("cool-project")
         assert project
-        assert len(project.pages) == 100
+        assert len(project.pages) == 10


### PR DESCRIPTION
Now users can run `./cli.py create-project` to create a new proofing
project from a PDF. This command uses the same underlying logic that we
use on Celery, but it doesn't require any Celery or Redis setup.

Test plan: Unit tests and ran `/cli.py create-project` on a local PDF. I
also uploaded a PDF through the uploader on the devserver to confirm
that the Celery code still works normally.