### PR TITLE
Fix PyMuPDF version as 1.20.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ pyasn1-modules==0.2.8
 pycparser==2.21
 Pygments==2.12.0
 pykakasi==2.2.1
-PyMuPDF==1.20.1
+PyMuPDF==1.20.2
 PyNaCl==1.5.0
 pyOpenSSL==22.0.0
 pyparsing==3.0.9


### PR DESCRIPTION
Fixes https://github.com/ambuda-org/ambuda/issues/134. Installs cleanly with this fix.