### PR TITLE
Fix side-by-side view

### DIFF
--- a/ambuda/static/css/style.css
+++ b/ambuda/static/css/style.css
@@ -101,7 +101,7 @@
   .side-by-side s-block.show-parsed > div.mula > s-lg {
     @apply cursor-auto;
   }
-  .side-by-side #text--content {
+  .side-by-side#text--content {
     @apply md:max-w-3xl;
   }
 

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -157,9 +157,9 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 {% block main %}
 {# FIXME: unify <article> and these three <div>s into fewer elements. #}
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
-  <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1">
+  <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1" :class="parseLayout">
   <div :class="fontSize">
-  <div :class="parseLayout" lang="sa">
+  <div lang="sa">
     {{ header() }}
     {% for block_ in html_blocks %}
     <s-block id="{{ block_.id }}">

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -157,6 +157,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 {% block main %}
 {# FIXME: unify <article> and these three <div>s into fewer elements. #}
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
+  {# Note: the "parseLayout" class must be kept in sync with the .side-by-side selector in the css file. #}
   <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1" :class="parseLayout">
   <div :class="fontSize">
   <div lang="sa">


### PR DESCRIPTION
Fixes https://github.com/ambuda-org/ambuda/issues/173. Basically, we needed to apply the `side-by-side` class to `#text--content` -- this way the CSS could expand its width so that there would be enough space to view the verses side by side.