### PR TITLE
Add Ashwin to about.people

### DIFF
--- a/ambuda/templates/about/people.html
+++ b/ambuda/templates/about/people.html
@@ -23,7 +23,7 @@ accessible to all.</p>
 </div>
 
 
-{# Until there's a good reason not to, let's just use an alphabetical order. #}
+{# Bios are in alphabetical order, which is simple and non-political. #}
 
 {% call bio("Arun Prasad", "Founder and Project Lead") %}
 <p>Arun is the creator of <a href="https://learnsanskrit.org">learnsanskrit.org</a>
@@ -37,12 +37,12 @@ fintech.</p>
 
 
 {% call bio("Ashwin Ramaswami", "Core Engineering") %}
-Ashwin has worked on a variety of projects around open source software
+<p>Ashwin has worked on a variety of projects around open source software
 development, digital humanities, cloud infrastructure and architecture, and
 cybersecurity. His interests in Sanskrit include Vedic texts and Vedantic
 commentaries. Ashwin holds a B.S. in Computer Science in Stanford University
 and is currently pursuing a J.D. degree at Georgetown University Law Center,
-where he works on technology law and policy.
+where he works on technology law and policy.</p>
 {% endcall %}
 
 

--- a/ambuda/templates/about/people.html
+++ b/ambuda/templates/about/people.html
@@ -22,6 +22,9 @@
 accessible to all.</p>
 </div>
 
+
+{# Until there's a good reason not to, let's just use an alphabetical order. #}
+
 {% call bio("Arun Prasad", "Founder and Project Lead") %}
 <p>Arun is the creator of <a href="https://learnsanskrit.org">learnsanskrit.org</a>
 and the Sanskrit short story project <a href="https://en.amarahasa.com">Amarahasa</a>.
@@ -30,6 +33,16 @@ literature radically accessible. Arun has an MS in Computer Science and a minor
 in Classics with a focus on Homeric Greek, both from Stanford University.
 By profession, he is a former Google Research engineer that works in climate
 fintech.</p>
+{% endcall %}
+
+
+{% call bio("Ashwin Ramaswami", "Core Engineering") %}
+Ashwin has worked on a variety of projects around open source software
+development, digital humanities, cloud infrastructure and architecture, and
+cybersecurity. His interests in Sanskrit include Vedic texts and Vedantic
+commentaries. Ashwin holds a B.S. in Computer Science in Stanford University
+and is currently pursuing a J.D. degree at Georgetown University Law Center,
+where he works on technology law and policy.
 {% endcall %}
 
 

--- a/ambuda/views/about.py
+++ b/ambuda/views/about.py
@@ -43,6 +43,7 @@ def name():
 def contact():
     return render_template("about/contact.html")
 
+
 @bp.route("/terms")
 def terms():
     return render_template("about/terms.html")


### PR DESCRIPTION
To recognize Ashwin's substantial and ongoing contributions to Ambuda, I'm
adding some information about him to our People page. "Core Engineering"
is a catch-all title for Ashwin's full-stack work, but we can always
change it later.