### PR TITLE
Revert "Set up CSP, unpkg -> jsdelivr"

### DIFF
--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -124,11 +124,4 @@ def create_app(config_env: str):
         }
     )
 
-    @app.after_request
-    def add_security_headers(resp):
-        resp.headers[
-            "Content-Security-Policy"
-        ] = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.google.com https://www.gstatic.com https://plausible.io; frame-src https://www.google.com; img-src 'self' data:;"
-        return resp
-
     return app

--- a/ambuda/templates/header-main-footer.html
+++ b/ambuda/templates/header-main-footer.html
@@ -7,7 +7,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/@indic-transliteration/sanscript@1.2.7/sanscript.min.js"></script>
     {# Load scripts before Alpine so that our init hooks are properly set up. #}
     <script defer src="/static/gen/main.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
+    <script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
 {% endblock %}
 
 


### PR DESCRIPTION
This reverts commit 86233b4af0ca900dbcb416e316e273d64a3de75c.

Context: CSP breaks inline CSS and JS in the proofing UI.