### PR TITLE
Make OCR button look more like a button

### DIFF
--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -111,11 +111,11 @@
           <div>
             <button
                 type="button"
-                class="p-2 hover:bg-slate-300"
+                class="btn bg-sky-700 text-white m-2 hover:bg-sky-900"
                 @click="runOCR"
                 :disabled="isRunningOCR"
-                x-text="isRunningOCR ? '...' : 'OCR'">
-              OCR
+                x-text="isRunningOCR ? 'Running ...' : 'Run OCR'">
+              Run OCR
             </button>
           </div>
           <div>


### PR DESCRIPTION
- Change text from "OCR" to "Run OCR".
- Add a margin and rounded corners to better indicate its button status.
- Change its background color so that it's more vivid.

Test plan: clicked the button.