### PR TITLE
Add character select menu to proofer

### DIFF
--- a/ambuda/static/css/style.css
+++ b/ambuda/static/css/style.css
@@ -37,7 +37,7 @@
 
   /* Dropdowns (e.g. in proofing editor) */
   .dropdown-pane {
-    @apply z-50 bg-white border absolute a-hover-underline w-48;
+    @apply z-50 bg-white border absolute a-hover-underline;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
   }
   .dropdown-item {

--- a/ambuda/static/js/proofer.js
+++ b/ambuda/static/js/proofer.js
@@ -218,4 +218,11 @@ export default () => ({
     this.changeSelectedText((s) => Sanscript.t(s, this.fromScript, this.toScript));
     this.saveSettings();
   },
+ 
+  // Character controls
+
+  copyCharacter(e) {
+    const character = e.target.textContent;
+    navigator.clipboard.writeText(character);
+  },
 });

--- a/ambuda/templates/base.html
+++ b/ambuda/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="description" content="{% block meta_description -%}
     A breakthrough Sanskrit library. Read our library of traditional Sanskrit texts with word-by-word analysis, integrated dictionary support, and so much more.
     {%- endblock %}">
-    <link rel="stylesheet" type="text/css" href="/static/gen/style.css?v=11">
+    <link rel="stylesheet" type="text/css" href="/static/gen/style.css?v=12">
     <link rel="icon" href="data:,">
     <title>{% block title %}{% endblock %}</title>
     {% block scripts %}{% endblock %}

--- a/ambuda/templates/header-main-footer.html
+++ b/ambuda/templates/header-main-footer.html
@@ -6,7 +6,7 @@
     <script async defer data-domain="ambuda.org" src="https://plausible.io/js/plausible.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/@indic-transliteration/sanscript@1.2.7/sanscript.min.js"></script>
     {# Load scripts before Alpine so that our init hooks are properly set up. #}
-    <script defer src="/static/gen/main.js?v=2"></script>
+    <script defer src="/static/gen/main.js?v=3"></script>
     <script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
 {% endblock %}
 

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -138,8 +138,9 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
         {{ _latin_char_row('ū ú û ù', 'grid-cols-8') }}
         {{ _latin_char_row('ē é ê è', 'grid-cols-8') }}
         {{ _latin_char_row('ō ó ô ò', 'grid-cols-8') }}
+        {{ _latin_char_row('ḥ ṁ ṃ', 'grid-cols-6') }}
         {{ _latin_char_row('ṅ ñ ṇ', 'grid-cols-6') }}
-        {{ _latin_char_row('ṁ ṃ ç', 'grid-cols-6') }}
+        {{ _latin_char_row('ṭ ḍ ś ṣ ç', 'grid-cols-10') }}
         {{ _devanagari_char_row('&#x0964; &#x0965; &#x093d; &#x0970;', 'grid-cols-4') }}
       </ul>
     </div>

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -45,6 +45,31 @@
 {% endmacro %}
 
 
+{#
+Print a row of Latin characters.
+Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
+{% macro _latin_char_row(chars, class) %}
+<div class="grid {{ class }}">
+{% for char in chars.split() %}
+  <button class="hover:bg-slate-100 rounded p-1">{{ char.upper()|safe }}</button>
+  <button class="hover:bg-slate-100 rounded p-1">{{ char|safe }}</button>
+{% endfor %}
+</div>
+{% endmacro %}
+
+
+{#
+Print a row of Devanagari characters.
+Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
+{% macro _devanagari_char_row(chars, class) %}
+<div class="text-xl grid {{ class }}">
+{% for char in chars.split() %}
+  <button class="hover:bg-slate-100 rounded p-1">{{ char|safe }}</button>
+{% endfor %}
+</div>
+{% endmacro %}
+
+
 {# Editing toolbar. #}
 {% macro toolbar() %}
 <nav class="border my-2 rounded flex">
@@ -52,7 +77,7 @@
     <button class="block p-2 hover:bg-slate-100"
        @click.prevent="open=!open"
        @click.outside="open=false">Layout</button>
-    <div x-show="open" class="dropdown-pane">
+    <div x-show="open" class="dropdown-pane w-48">
       <ul class="text-sm" @click.prevent="open=false">
         {{ dropdown_item('displaySideBySide', 'Image right, text left') }}
         {{ dropdown_item('displayTopAndBottom', 'Image above, text below') }}
@@ -64,7 +89,7 @@
     <button class="block p-2 hover:bg-slate-100"
        @click.prevent="open=!open"
        @click.outside="open=false">Mark text</button>
-    <div x-show="open" class="dropdown-pane">
+    <div x-show="open" class="dropdown-pane w-48">
       <ul class="text-sm" @click.prevent="open=false">
         {{ dropdown_item('markAsError', 'Mark as error') }}
         {{ dropdown_item('markAsFix', 'Mark as fix') }}
@@ -98,6 +123,25 @@
           @click.prevent="transliterate; open=false">
           Transliterate selected text
       </button>
+    </div>
+  </div>
+
+  <div x-data="{open: false}" class="relative">
+    <button class="block p-2 hover:bg-slate-100"
+       @click.prevent="open=!open"
+       @click.outside="open=false">Characters</button>
+    <div x-show="open" class="p-2 dropdown-pane w-60" @click.prevent="copyCharacter">
+      <p class="text-xs text-center mb-2">Click a character to copy it.</p>
+      <ul class="text-center">
+        {{ _latin_char_row('ā á â à', 'grid-cols-8') }}
+        {{ _latin_char_row('ī í î ì', 'grid-cols-8') }}
+        {{ _latin_char_row('ū ú û ù', 'grid-cols-8') }}
+        {{ _latin_char_row('ē é ê è', 'grid-cols-8') }}
+        {{ _latin_char_row('ō ó ô ò', 'grid-cols-8') }}
+        {{ _latin_char_row('ṅ ñ ṇ', 'grid-cols-6') }}
+        {{ _latin_char_row('ṁ ṃ ç', 'grid-cols-6') }}
+        {{ _devanagari_char_row('&#x0964; &#x0965; &#x093d; &#x0970;', 'grid-cols-4') }}
+      </ul>
     </div>
   </div>
 </nav>

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -141,7 +141,8 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
         {{ _latin_char_row('ḥ ṁ ṃ', 'grid-cols-6') }}
         {{ _latin_char_row('ṅ ñ ṇ', 'grid-cols-6') }}
         {{ _latin_char_row('ṭ ḍ ś ṣ ç', 'grid-cols-10') }}
-        {{ _devanagari_char_row('&#x0964; &#x0965; &#x093d; &#x0970;', 'grid-cols-4') }}
+        {{ _devanagari_char_row('&#x0964; &#x0965; &#x093d; &#x0970; &#xa8f2; &#xa8f3;',
+            'grid-cols-6') }}
       </ul>
     </div>
   </div>

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -136,6 +136,7 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
         {{ _latin_char_row('ā á â à', 'grid-cols-8') }}
         {{ _latin_char_row('ī í î ì', 'grid-cols-8') }}
         {{ _latin_char_row('ū ú û ù', 'grid-cols-8') }}
+        {{ _latin_char_row('ṛ ṝ ḷ ḹ', 'grid-cols-8') }}
         {{ _latin_char_row('ē é ê è', 'grid-cols-8') }}
         {{ _latin_char_row('ō ó ô ò', 'grid-cols-8') }}
         {{ _latin_char_row('ḥ ṁ ṃ', 'grid-cols-6') }}


### PR DESCRIPTION
The menu spports a variety of accented Latin characters and special
Devanagari characters. The menu looks a little crude but is workable for
now.

Test plan: used the menu on dev. A Jest test here would basically just
be testing the mock.

<img width="246" alt="image" src="https://user-images.githubusercontent.com/1429776/186702248-fb330acd-22ad-4bb4-8d3e-55f248981435.png">
