### PR TITLE
Add transliteration menu

### DIFF
--- a/ambuda/static/js/proofer.js
+++ b/ambuda/static/js/proofer.js
@@ -1,4 +1,4 @@
-/* global Alpine, $, OpenSeadragon, IMAGE_URL */
+/* global Alpine, $, OpenSeadragon, Sanscript, IMAGE_URL */
 /* Transcription and proofreading interface. */
 
 import { $ } from './core.ts';
@@ -49,6 +49,10 @@ export default () => ({
   textZoom: 1,
   imageZoom: null,
   layout: 'side-by-side',
+  // [transliteration] the source script
+  fromScript: 'hk',
+  // [transliteration] the destination script
+  toScript: 'devanagari',
 
   // Internal-only
   layoutClasses: CLASSES_SIDE_BY_SIDE,
@@ -90,6 +94,9 @@ export default () => ({
         this.imageZoom = settings.imageZoom;
         this.layout = settings.layout || this.layout;
 
+        this.fromScript = settings.fromScript || this.fromScript;
+        this.toScript = settings.toScript || this.toScript;
+
         // Normalize layout value to protect against some recent refactoring.
         if (!ALL_LAYOUTS.includes(this.layout)) {
           this.layout = LAYOUT_SIDE_BY_SIDE;
@@ -104,6 +111,8 @@ export default () => ({
       textZoom: this.textZoom,
       imageZoom: this.imageZoom,
       layout: this.layout,
+      fromScript: this.fromScript,
+      toScript: this.toScript,
     };
     localStorage.setItem(CONFIG_KEY, JSON.stringify(settings));
   },
@@ -178,25 +187,29 @@ export default () => ({
 
   // Markup controls
 
-  markAs(before, after) {
+  changeSelectedText(callback) {
     // FIXME: more idiomatic way to get this?
     const $textarea = $('#content');
     const start = $textarea.selectionStart;
     const end = $textarea.selectionEnd;
     const { value } = $textarea;
     const selectedText = value.substr(start, end - start);
-    $textarea.value = value.substr(0, start) + before + selectedText + after + value.substr(end);
+    $textarea.value = value.substr(0, start) + callback(selectedText) + value.substr(end);
   },
   markAsError() {
-    this.markAs('<error>', '</error>');
+    this.changeSelectedText((s) => `<error>${s}</error>`);
   },
   markAsFix() {
-    this.markAs('<fix>', '</fix>');
+    this.changeSelectedText((s) => `<fix>${s}</fix>`);
   },
   markAsUnclear() {
-    this.markAs('<flag>', '</flag>');
+    this.changeSelectedText((s) => `<flag>${s}</flag>`);
   },
   markAsFootnoteNumber() {
-    this.markAs('[^', ']');
+    this.changeSelectedText((s) => `[^${s}]`);
+  },
+  transliterate() {
+    this.changeSelectedText((s) => Sanscript.t(s, this.fromScript, this.toScript));
+    this.saveSettings();
   },
 });

--- a/ambuda/static/js/proofer.js
+++ b/ambuda/static/js/proofer.js
@@ -193,8 +193,14 @@ export default () => ({
     const start = $textarea.selectionStart;
     const end = $textarea.selectionEnd;
     const { value } = $textarea;
+
     const selectedText = value.substr(start, end - start);
-    $textarea.value = value.substr(0, start) + callback(selectedText) + value.substr(end);
+    const replacement = callback(selectedText);
+    $textarea.value = value.substr(0, start) + replacement + value.substr(end);
+
+    // Update selection state and focus for better UX.
+    $textarea.setSelectionRange(start, start + replacement.length);
+    $textarea.focus();
   },
   markAsError() {
     this.changeSelectedText((s) => `<error>${s}</error>`);

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -81,8 +81,6 @@
       <div class="mb-2 flex justify-between">
         <label>From:</label>
         <select x-model="fromScript">
-          <option value="devanagari">Devanagari</option>
-          <option value="iast">IAST</option>
           <option value="hk">Harvard-Kyoto</option>
           <option value="itrans">ITRANS</option>
         </select>
@@ -93,8 +91,6 @@
         <select x-model="toScript">
           <option value="devanagari">Devanagari</option>
           <option value="iast">IAST</option>
-          <option value="hk">Harvard-Kyoto</option>
-          <option value="itrans">ITRANS</option>
         </select>
       </div>
 

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -40,7 +40,7 @@
 
 {% macro dropdown_item(fn, text) %}
 <li>
-  <button class="dropdown-item" @click.prevent="{{ fn }}">{{ text }}</button>
+  <button class="dropdown-item" @click.prevent="{{ fn }}">{{ text|safe }}</button>
 </li>
 {% endmacro %}
 
@@ -71,6 +71,37 @@
         {{ dropdown_item('markAsUnclear', 'Mark as unclear') }}
         {{ dropdown_item('markAsFootnoteNumber', 'Mark as footnote number') }}
       </ul>
+    </div>
+  </div>
+
+  <div x-data="{open: false}" class="relative" @click.outside="open=false">
+    <button class="block p-2 hover:bg-slate-100"
+       @click.prevent="open=!open">Transliterate</button>
+    <div x-show="open" class="dropdown-pane w-64 p-2">
+      <div class="mb-2 flex justify-between">
+        <label>From:</label>
+        <select x-model="fromScript">
+          <option value="devanagari">Devanagari</option>
+          <option value="iast">IAST</option>
+          <option value="hk">Harvard-Kyoto</option>
+          <option value="itrans">ITRANS</option>
+        </select>
+      </div>
+
+      <div class="mb-2 flex justify-between">
+        <label>To:</label>
+        <select x-model="toScript">
+          <option value="devanagari">Devanagari</option>
+          <option value="iast">IAST</option>
+          <option value="hk">Harvard-Kyoto</option>
+          <option value="itrans">ITRANS</option>
+        </select>
+      </div>
+
+      <button class="mt-4 btn btn-basic block w-full"
+          @click.prevent="transliterate; open=false">
+          Transliterate selected text
+      </button>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
A flexible menu that transliterates between two arbitrary scripts.
To keep the tool user-friendly for now, I pared down the list to
remove schemes and encodings that seem less relevant.

Test plan: unit tests and ran the tool on dev.

<img width="260" alt="image" src="https://user-images.githubusercontent.com/1429776/186715059-21bcf914-dc5a-475f-a8e5-9dd402757bb4.png">
