### PR TITLE
Fix multiple production regressions

### DIFF
--- a/ambuda/seed/dcs.py
+++ b/ambuda/seed/dcs.py
@@ -64,6 +64,8 @@ def iter_parse_data(path: Path):
                     xml_id = value
                     _, _, block_slug = xml_id.partition(".")
             elif line:
+                if line.count("\t") != 3:
+                    raise ValueError(f'Line "{line}" must have exactly three fields.')
                 buf.append(line)
             else:
                 yield block_slug, "\n".join(buf)

--- a/ambuda/utils/cheda.py
+++ b/ambuda/utils/cheda.py
@@ -61,6 +61,7 @@ LAKARAS = {
     "lot": "imperative",
     "lan": "imperfect",
     "vidhilin": "optative",
+    "ashirlin": "benedictive",
     "lun": "aorist",
     "lun_unaug": "aorist (unaugmented)",
     "lrn": "conditional",

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -119,7 +119,7 @@ def edit(slug):
         session.commit()
 
         flash("Saved changes.", "success")
-        return redirect(url_for("proofing.projects.summary", slug=slug))
+        return redirect(url_for("proofing.project.summary", slug=slug))
 
     return render_template(
         "proofing/projects/edit.html",

--- a/test/ambuda/utils/test_parsing.py
+++ b/test/ambuda/utils/test_parsing.py
@@ -10,6 +10,7 @@ from ambuda.utils.cheda import readable_parse
         ("pos=a,g=f,c=2,n=d", "adjective, feminine accusative dual"),
         ("pos=va,g=n,c=3,n=p", "participle, neuter instrumental plural"),
         ("pos=v,p=3,n=s,l=lat", "verb, third-person singular present"),
+        ("pos=v,p=2,n=s,l=ashirlin", "verb, second-person singular benedictive"),
         ("pos=n,g=m,comp=y", "noun, compounded"),
         ("pos=i", "indeclinable"),
     ],

--- a/test/ambuda/views/proofing/test_project.py
+++ b/test/ambuda/views/proofing/test_project.py
@@ -21,6 +21,35 @@ def test_edit__auth(rama_client):
     assert "Edit:" in resp.text
 
 
+def test_edit__auth__post_succeeds(rama_client):
+    resp = rama_client.post(
+        "/proofing/test-project/edit",
+        data={
+            "description": "some description",
+            "page_numbers": "",
+            "title": "some title",
+            "author": "some author",
+            "editor": "",
+            "publisher": "some publisher",
+            "publication_year": "",
+        },
+    )
+    assert resp.status_code == 302
+    print(resp.headers["Location"] == "/proofing/test-project/")
+
+
+def test_edit__auth__post_fails(rama_client):
+    resp = rama_client.post(
+        "/proofing/test-project/edit",
+        data={
+            # Bade page spec forces form to fail validation
+            "page_numbers": "garbage in, garbage out",
+        },
+    )
+    assert resp.status_code == 200.0
+    assert "page number spec" in resp.text
+
+
 def test_edit__auth__bad_project(rama_client):
     resp = rama_client.get("/proofing/unknown/edit")
     assert resp.status_code == 404


### PR DESCRIPTION
This fixes the following causes of HTTP 500 errors:

- POST on an `edit` page redirects to a non-existing route
- `ashirlin` parse code is not recognized
- one of our parse data rows contains more than 3 columns. (Fixed
  upstream)

Test plan: unit tests