### PR TITLE
Add page to see all proofing threads at once 

### DIFF
--- a/ambuda/templates/proofing/index.html
+++ b/ambuda/templates/proofing/index.html
@@ -24,6 +24,7 @@
 
 <ul class="list-disc">
   <li><a href="{{ url_for("proofing.create_project") }}">Create a new project</a></li>
+  <li><a href="{{ url_for("proofing.talk") }}">Talk</a></li>
   <li><a href="{{ url_for("proofing.recent_changes") }}">Recent changes</a></li>
   <li><a href="{{ url_for("proofing.tagging.index") }}">Tagging</a></li>
 </ul>

--- a/ambuda/templates/proofing/talk.html
+++ b/ambuda/templates/proofing/talk.html
@@ -1,0 +1,31 @@
+{% extends 'proofing/base.html' %}
+{% import "macros/proofing.html" as m %}
+{% import "macros/proofing-talk.html" as m_talk %}
+{% from "macros/forms.html" import field %}
+
+{% block title %}Project Talk | Ambuda{% endblock %}
+
+{% block content %}
+<div class="prose">
+  <h1>Proofing talk</h1>
+
+  <p>Recent discussion across all projects.</p>
+</div>
+
+{% for project, thread in all_threads %}
+  {% set project_url = url_for('proofing.project.summary', slug=project.slug) %}
+  {% set thread_url = url_for('proofing.talk.thread', project_slug=project.slug, thread_id=thread.id) %}
+  {% set author_url = url_for('proofing.users.user', username=thread.author.username) %}
+  <li class="p-4 border-t a-hover-underline flex justify-between">
+    <div>
+      <a href="{{ thread_url }}">{{ thread.title }}</a>
+      <p class="text-sm text-slate-400">
+        <a href="{{ project_url }}">{{ project.title }}</a>
+        | Created by <a href="{{ author_url }}">{{ thread.author.username }}</a>
+      </p>
+    </div>
+    <p class="text-sm">{{ thread.updated_at|time_ago }}</p>
+  </li>
+{% endfor %}
+
+{% endblock %}

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -156,3 +156,16 @@ def recent_changes():
         session.query(db.Revision).order_by(db.Revision.created.desc()).limit(100).all()
     )
     return render_template("proofing/recent-changes.html", revisions=recent_revisions)
+
+
+@bp.route("/talk")
+def talk():
+    """Show discussion across all projects."""
+    session = q.get_session()
+    projects = q.projects()
+
+    # FIXME: optimize this once we have a higher thread volume.
+    all_threads = [(p, t) for p in projects for t in p.board.threads]
+    all_threads.sort(key=lambda x: x[1].updated_at, reverse=True)
+
+    return render_template("proofing/talk.html", all_threads=all_threads)

--- a/test/ambuda/views/proofing/test_main.py
+++ b/test/ambuda/views/proofing/test_main.py
@@ -45,3 +45,8 @@ def test_create_project__unauth(client):
 def test_create_project__auth(rama_client):
     resp = rama_client.get("/proofing/create-project")
     assert resp.status_code == 200
+
+
+def test_talk(client):
+    resp = client.get("/proofing/talk")
+    assert "Proofing talk" in resp.text


### PR DESCRIPTION
Our discussion threads don't have a notifications mechanism, which
greatly reduces their usefulness. As a quick workaround, create a single
link that shows all discussion across all projects.

The implementation is a litle hacky, but we can refine if it this
becomes a popular feature.

Test plan: unit tests and opened the new page on the dev server.