### PR TITLE
Add user guide for page editor

### DIFF
--- a/ambuda/filters.py
+++ b/ambuda/filters.py
@@ -7,8 +7,15 @@ from indic_transliteration import sanscript
 from markdown_it import MarkdownIt
 
 
-# Markdown parser.
-# Docs: https://markdown-it-py.readthedocs.io/en/latest/using.html
+#: A markdown parser for user-generated text.
+#:
+#: - `js-default` is like Commonmark but it disables raw HTML.
+#: - `typographer` enables specific typography improvements:
+#:   - `replacements` replaces `---` with `&mdash;`, etc.
+#:   - `smartquotes` replaces basic quotes with opening and closing quotes.
+#:   - `linkify` converts URLs like `"github.com"` into clickable links.
+#:
+#: Docs: https://markdown-it-py.readthedocs.io/en/latest/using.html
 MARKDOWN = MarkdownIt("js-default", {"typographer": True, "linkify": True}).enable(
     ["replacements", "smartquotes", "linkify"]
 )

--- a/ambuda/static/js/proofer.js
+++ b/ambuda/static/js/proofer.js
@@ -218,7 +218,7 @@ export default () => ({
     this.changeSelectedText((s) => Sanscript.t(s, this.fromScript, this.toScript));
     this.saveSettings();
   },
- 
+
   // Character controls
 
   copyCharacter(e) {

--- a/ambuda/templates/proofing/complete-guidelines.html
+++ b/ambuda/templates/proofing/complete-guidelines.html
@@ -117,13 +117,13 @@ we should write <i>çru</i> and not <i>śru</i>.
 <li>
 <p>
 <strong>Follow the book's script conventions.</strong> If the book uses
-Devanagari, we should use Devanagari, not Roman script. or some other convention.
+Devanagari, we should use Devanagari, not Roman script or some other convention.
 
 
 <li>
 <p>
 <strong>Follow the book's word-splitting conventions.</strong> Different books
-have different conventions for splitting long blocks of Devanagari text, or for
+have different conventions for splitting long blocks of Devanagari text or for
 adding and removing Sanskrit's sound changes ({{ 'sandhi'|d }}). We follow the
 conventions of the book regardless of our personal preference.
 
@@ -150,7 +150,7 @@ good use of time.
 
 {{ _h2('characters', 'eol-hyphens') }}
 
-<p>If the printed line ends with a hyphen, keep the hyphen. Our program uses
+<p>If the printed line ends with a hyphen, we keep the hyphen. Our program uses
 these hyphens to stitch together different lines:
 
 {% call _example() -%}
@@ -206,6 +206,8 @@ We delete spaces at the end of a line:
 {{ _h('paragraphs') }}
 
 {{ _h2('paragraphs', 'para-breaks') }}
+
+<p>Keep line breaks and line-ending hyphens.</p>
 
 <p>Proofing is easier when we can quickly compare our digitized text to the
 original image. Line breaks and line-breaking make our digitized text look more

--- a/ambuda/templates/proofing/editor-guide.html
+++ b/ambuda/templates/proofing/editor-guide.html
@@ -3,6 +3,10 @@
 {% import "proofing/pages/editor-components.html" as editor %}
 
 
+{# Show a button icon inline. #}
+{% macro _button(text) %}<span class="p-1 bg-slate-200">{{ text|safe }}</span>{% endmacro %}
+
+
 {# Embed an HTML widget as a figure. #}
 {% macro html_figure(caption) %}
 <figure class="my-12">
@@ -76,30 +80,57 @@ below:</p>
 {% endcall %}
 
 <div class="prose">
-<p>The menu bar contains various powerful features to help you transcribe a
-page:</p>
+<p>The menu bar contains various features to help you transcribe a page.</p>
+
+<p><dfn>Layout</dfn> lets you change the layout of different parts of the
+editor:</p>
 
 <ul>
-  <li><p><dfn>Layout</dfn> lets you change the layout of different parts of the
-      editor. For example, one user like to have the page image above the text
-      she's transcribing, whereas anotehr might like to have the page sit
-      side-by-side with the text.</p></li>
-
-  <li><p><dfn>Markup</dfn> lets you annotate parts of the text. These
-      annotations are mostly for other proofers. For example, you can <kbd>Mark
-      as unclear</kbd> to indicate that a piece of text is hard to read or
-      understand.</p></li>
-
-  <li><p><dfn>Transliterator</dfn> lets you convert the text you select into
-      Devanagari or IAST. The transliterater is useful if you don't have any
-      other way to type Devanagari or IAST on your computer.</p></li>
-
-  <li><p><dfn>Characters</dfn> lets you quickly select special characters that
-      are hard to type. These include various accented Roman characters and a
-      few special Devanagari symbols.</p></li>
-
-  <li><dfn>Help</dfn> loads the page you're reading right now.</p></li>
+  <li><p><i>Image right, text left</i> shows the image to the right of the
+      text. This view is great for simple texts and for viewing the page as a
+      whole.</p></li>
+  <li><p><i>Image above, text below</i> shows the image on the right and the
+      text on the left. This view is great for complicated work or for focusing
+      on individual words.</p></li>
 </ul>
+
+<p><dfn>Markup</dfn> lets you annotate different parts of the text:</p>
+
+{% set footnote_docs =  url_for("proofing.complete_guide", _anchor='para-footnotes') %}
+<ul>
+  <li><p>Use <i>Mark as error</i> to annotate typos in the source text. We will
+      not display these errors in our final text, but it's important to keep
+      track of them so that it's clear which changes came from the source text
+      an which changes came from our own judgment.</p></li>
+  <li><p>Use <i>Mark as fix</i> to annotate fixes to errors in the source
+      text.</p></li>
+  <li><p>Use <i>Mark as unclear</i> to annotate text that is difficult to read
+      or understand. Other more experienced proofers can help take a look and
+      resolve the issue.</p></li>
+  <li><p>Use <i>Mark as footnote</i> to annotate footnote numbers and letters.
+      For details on what you should annotate, see our <a href="{{ footnote_docs }}">
+      complete proofing guide</a>.</p></li>
+</ul>
+
+<p><dfn>Transliterator</dfn> lets you convert the text you select into
+Devanagari or IAST. The transliterator is useful if you don't have any
+other way to type Devanagari or IAST on your computer.</p>
+
+{% set itrans = "https://en.wikipedia.org/wiki/ITRANS" %}
+{% set hk = "https://en.wikipedia.org/wiki/Harvard-Kyoto" %}
+<ul>
+  <li><p>Use <i>From</i> to define the input encoding. We currently support
+      <a href="{{ itrans }}">ITRANS</a> and <a href="{{ hk }}">Harvard-Kyoto</a>.
+      </p></li>
+  <li><p>Use <i>To</i> to define the output script. We currently support
+      Devanagari and IAST.</p></li>
+</ul>
+
+<p><dfn>Characters</dfn> lets you quickly select special characters that
+are hard to type. These include various accented Roman characters and a
+few special Devanagari symbols.</p>
+
+<dfn>Help</dfn> loads the page you're reading right now.</p></li>
 
 
 <h2>The text editor</h2>
@@ -134,6 +165,11 @@ that will try to recognize all of the letters in the original image.</p>
 <p>The <i>A<sup>+</sup></i> and <i>A<sup>-</sup></i> buttons in the upper-right
 let you change the text size, in case you find it hard to read.</p>
 
+<ul>
+  <li><p>Use {{ _button('A<sup>+</sup>') }} to increase the text size.</p></li>
+  <li><p>Use {{ _button('A<sup>-</sup>') }} to decrease the text size.</p></li>
+</ul>
+
 
 <h2>The image viewer</h2>
 
@@ -155,9 +191,23 @@ let you change the text size, in case you find it hard to read.</p>
 {% endcall %}
 
 <div class="prose">
+
 <p>The image viewer contains various controls that let you change the image's
 zoom and rotation. We provide these controls so that you can view an image
 comfortably and clearly.</p>
+
+<ul>
+  <li><p>Use {{ _button('&#x1f50d;<sup>+</sup>') }} to zoom in and increase the
+      image size.</p></li>
+  <li><p>Use {{ _button('&#x1f50d;<sup>0</sup>') }} to reset the image
+      zoom.</p></li>
+  <li><p>Use {{ _button('&#x1f50d;<sup>-</sup>') }} to zoom out and decrease
+      the image size.</p></li>
+  <li><p>Use {{ _button('&#x27f2;') }} to rotate the image counterclockwise by
+      90 degrees.</p></li>
+  <li><p>Use {{ _button('&#x27f3;') }} to rotate the image clockwise by 90
+      degrees.</p></li>
+</ul>
 
 
 <h2>The submission form</h2>
@@ -190,11 +240,20 @@ below:</p>
 
 <div class="prose">
 
-<p>The submission form is how you save all of your changes. If your change is
-subtle, you can leave an optional summary of your changes.</p>
+<p>If your change is subtle, you can leave an optional summary of your
+changes. Most changes don't need an explicit summary.</p>
 
 <p>The <i>Status</i> dropdown is critical, as it lets others know what the
-status of this page is.</p>
+status of this page is:</p>
+
+<ul>
+  <li><p>Use <i>Needs more work</i> if the page doesn't look good to you.</p></li>
+  <li><p>Use <i>Proofread once</i> if the page looks good to you.</p></li>
+  <li><p>Use <i>Proofread twice</i> if the page looks good to you <em>and</em>
+      someone else has marked it as <i>Proofread once</i>.</p></li>
+  <li><p>Use <i>No useful text</i> if the page is empty or irrelevant to the
+      project.</p></li>
+</ul>
 
 
 <h2>How to get more help</h2>

--- a/ambuda/templates/proofing/editor-guide.html
+++ b/ambuda/templates/proofing/editor-guide.html
@@ -199,9 +199,9 @@ status of this page is.</p>
 
 <h2>How to get more help</h2>
 
-<p>If you encounter errors while using this tool, the easiest way to let us
-know about them is to <a href="{{ url_for('about.contact') }}">contact us</a>
-directly. We'll fix the error as soon as we can.</p>
+<p>If you still have questions or comments about this tool, the easiest way to
+let us know about them is to <a href="{{ url_for('about.contact') }}">contact
+us</a> directly. We'll get back to you as soon as we can.</p>
 
 </div>
 {% endblock %}

--- a/ambuda/templates/proofing/editor-guide.html
+++ b/ambuda/templates/proofing/editor-guide.html
@@ -1,0 +1,207 @@
+{% extends 'base-text.html' %}
+{% import "macros/components.html" as components %}
+{% import "proofing/pages/editor-components.html" as editor %}
+
+
+{# Embed an HTML widget as a figure. #}
+{% macro html_figure(caption) %}
+<figure class="my-12">
+  <div class="border p-4">
+    {{ caller() }}
+  </div>
+  <figcaption class="text-sm text-slate-600 mt-2 text-center">{{ caption }}</figcaption>
+</figure>
+{% endmacro %}
+
+
+{% block title %}How to use the page editor | Ambuda{% endblock %}
+
+
+{% block content %}
+<div class="prose">
+<h1>How to use the page editor</h1>
+
+<p>Our simple and powerful <dfn>page editor</dfn> makes it easy to proofread a
+printed page. This document describes how to use our page editor.</p>
+
+<p>If you instead want to learn more about our proofing work and how you can
+get started, see our <a href="{{ url_for('proofing.beginners_guide')
+}}">beginner's guide to proofing</a>.</p>
+
+
+<h2>The navigation bar</h2>
+
+<p>The page editor starts with a simple <dfn>navigation bar</dfn>, which you
+can see below:</p>
+</div>
+
+{% call html_figure('The navigation bar for a sample project.') %}
+{{ editor.navigation_bar(
+    project={ "title": "madhurAvijayam"|d },
+    cur={ "slug": "14", "status": { "name": "reviewed-1" }},
+    prev={},
+    next={}) }}
+{% endcall %}
+
+<div class="prose">
+
+<p>The navigation bar shows that we're viewing page 14 of the {{
+'madhurAvijayam'|d }} project. You can click on the name of the project to
+return to the main project page.</p>
+
+<p>The <i>History</i> link will take you to the full edit history for this
+page, and the <i>&larr;</i> and <i>&rarr;</i> links will take you to the
+previous and next page, respectively.</p>
+
+<p>Finally, the <i>Proofread once</i> text shows that one person has reviewed
+this page and judged that its transcription was accurate.</p>
+</div>
+
+<div class="prose">
+<h2>The menu bar</h2>
+
+<p>Below the navigation bar is the <dfn>menu bar</dfn>, which you can see
+below:</p>
+</div>
+
+{% call html_figure('A menu bar with multiple options available.') %}
+{% set button_css = "block p-2 hover:bg-slate-100 cursor-pointer" %}
+<nav class="border my-2 rounded flex">
+  <span class="{{ button_css }}">Layout</span>
+  <span class="{{ button_css }}">Markup</span>
+  <span class="{{ button_css }}">Transliterator</span>
+  <span class="{{ button_css }}">Characters</span>
+  <span class="{{ button_css }}">Help</span>
+</nav>
+{% endcall %}
+
+<div class="prose">
+<p>The menu bar contains various powerful features to help you transcribe a
+page:</p>
+
+<ul>
+  <li><p><dfn>Layout</dfn> lets you change the layout of different parts of the
+      editor. For example, one user like to have the page image above the text
+      she's transcribing, whereas anotehr might like to have the page sit
+      side-by-side with the text.</p></li>
+
+  <li><p><dfn>Markup</dfn> lets you annotate parts of the text. These
+      annotations are mostly for other proofers. For example, you can <kbd>Mark
+      as unclear</kbd> to indicate that a piece of text is hard to read or
+      understand.</p></li>
+
+  <li><p><dfn>Transliterator</dfn> lets you convert the text you select into
+      Devanagari or IAST. The transliterater is useful if you don't have any
+      other way to type Devanagari or IAST on your computer.</p></li>
+
+  <li><p><dfn>Characters</dfn> lets you quickly select special characters that
+      are hard to type. These include various accented Roman characters and a
+      few special Devanagari symbols.</p></li>
+
+  <li><dfn>Help</dfn> loads the page you're reading right now.</p></li>
+</ul>
+
+
+<h2>The text editor</h2>
+
+<p>Next is the <dfn>text editor</dfn>, which you can see below:</p>
+</div>
+
+{% call html_figure('A text editor with multiple options.') %}
+<div class="border">
+  <div class="bg-slate-200 flex justify-between">
+    <div>
+      <button type="button" class="btn bg-sky-700 text-white m-2 hover:bg-sky-900">
+        Run OCR
+      </button>
+    </div>
+    <div>
+      {{ editor.alpine_button("A<sup>+</sup>", "increaseTextSize") }}
+      {{ editor.alpine_button("A<sup>-</sup>", "decreaseTextSize") }}
+    </div>
+  </div>
+  <textarea id="content" name="content" required=""
+    class="grow p-2 md:p-4 w-full resize-none h-32">{{ data }}</textarea>
+</div>
+{% endcall %}
+
+<div class="prose">
+<p>If the text box doesn't have any content, you should first click the big
+<i>Run OCR</i> button in the upper-left. This button will run <dfn>optical
+    character recognition</dfn>, a sophisticated machine learning algorithm
+that will try to recognize all of the letters in the original image.</p>
+
+<p>The <i>A<sup>+</sup></i> and <i>A<sup>-</sup></i> buttons in the upper-right
+let you change the text size, in case you find it hard to read.</p>
+
+
+<h2>The image viewer</h2>
+
+<p>Next we have the <dfn>image viewer</dfn>, which you can see below:</p>
+</div>
+
+{% call html_figure('An image viewer with various options. No image is displayed.') %}
+<div class="flex flex-col flex-1 border bg-slate-100 border">
+  <div class="bg-slate-200">
+    {{ editor.alpine_button("&#x1f50d;<sup>+</sup>", "") }}
+    {{ editor.alpine_button("&#x1f50d;&#x00b0;", "") }}
+    {{ editor.alpine_button("&#x1f50d;<sup>-</sup>", "") }}
+    {{ editor.osd_button("osd-rotate-left", "&#x27f2;") }}
+    {{ editor.osd_button("osd-rotate-right", "&#x27f3;") }}
+  </div>
+
+  <div id="osd-image" class="h-32"></div>
+</div>
+{% endcall %}
+
+<div class="prose">
+<p>The image viewer contains various controls that let you change the image's
+zoom and rotation. We provide these controls so that you can view an image
+comfortably and clearly.</p>
+
+
+<h2>The submission form</h2>
+
+<p>Last but not least, we have the <dfn>submission form</dfn>, which you can see
+below:</p>
+</div>
+
+{% call html_figure('The submission form.') %}
+<div class="p-4 mt-4 bg-slate-200">
+  <label class="text-slate-600 mb-2 block">Summary of changes made</label>
+  <input type="text" class="block rounded bg-white w-full mb-4 p-2"></input>
+
+  <label class="text-slate-600 mb-2 block">Status</label>
+  <select class="block rounded bg-white w-full mb-4 p-2">
+    <option>Needs more work</option>
+    <option>Proofread once</option>
+    <option>Proofread twice</option>
+    <option>No useful text</option>
+  </select>
+
+  {% set cc0 = "https://creativecommons.org/publicdomain/zero/1.0/" %}
+  <p class="my-4 text-sm">By saving your changes, you agree to release your
+  contribution under the <a class="underline" href="{{ cc0 }}">CC0 (public
+  domain) license</a>.</p>
+  <a href="#" class="inline-block btn btn-submit" type="submit">Publish changes</a>
+</div>
+{% endcall %}
+
+
+<div class="prose">
+
+<p>The submission form is how you save all of your changes. If your change is
+subtle, you can leave an optional summary of your changes.</p>
+
+<p>The <i>Status</i> dropdown is critical, as it lets others know what the
+status of this page is.</p>
+
+
+<h2>How to get more help</h2>
+
+<p>If you encounter errors while using this tool, the easiest way to let us
+know about them is to <a href="{{ url_for('about.contact') }}">contact us</a>
+directly. We'll fix the error as soon as we can.</p>
+
+</div>
+{% endblock %}

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -1,154 +1,7 @@
 {% extends 'proofing/base.html' %}
 {% import "macros/proofing.html" as m %}
-{% import "macros/components.html" as components %}
-
-
-{% macro osd_button(id, text) %}
-<button type="button" id="{{ id }}" class="p-2 hover:bg-slate-300">{{ text|safe }}</button>
-{% endmacro %}
-
-
-{% macro alpine_button(text, click) %}
-<button type="button" class="p-2 hover:bg-slate-300" @click="{{ click }}">
-  {{ text|safe }}
-</button>
-{% endmacro %}
-
-
-{# Page information and navigation options. #}
-{% macro small_header(project, cur, prev, next) %}
-<header class="border-b py-2 flex justify-between items-center mb-4 a-hover-underline">
-  <h1 class="text">
-    <a class="text-black font-bold"
-        href="{{ url_for("proofing.project.summary", slug=project.slug) }}">
-       {{ project.title }}</a>
-    / {{ cur.slug }}
-  </h1>
-  {% set edit_url = url_for("proofing.page.edit", project_slug=project.slug, page_slug=cur.slug) %}
-  {% set history_url = url_for("proofing.page.history", project_slug=project.slug, page_slug=cur.slug) %}
-  <nav class="flex text-slate-700 text-md">
-    <a class="block p-2" href="{{ edit_url }}">Edit</a>
-    <a class="block p-2" href="{{ history_url }}">History</a>
-    {% set prev_url = url_for('proofing.page.edit', project_slug=project.slug, page_slug=prev.slug) %}
-    {% set next_url = url_for('proofing.page.edit', project_slug=project.slug, page_slug=next.slug) %}
-    <a class="block p-2" href="{{ prev_url }}">&larr;</a>
-    <a class="block p-2" href="{{ next_url }}">&rarr;</a>
-  </nav>
-</header>
-{% endmacro %}
-
-
-{% macro dropdown_item(fn, text) %}
-<li>
-  <button class="dropdown-item" @click.prevent="{{ fn }}">{{ text|safe }}</button>
-</li>
-{% endmacro %}
-
-
-{#
-Print a row of Latin characters.
-Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
-{% macro _latin_char_row(chars, class) %}
-<div class="grid {{ class }}">
-{% for char in chars.split() %}
-  <button class="hover:bg-slate-100 rounded p-1">{{ char.upper()|safe }}</button>
-  <button class="hover:bg-slate-100 rounded p-1">{{ char|safe }}</button>
-{% endfor %}
-</div>
-{% endmacro %}
-
-
-{#
-Print a row of Devanagari characters.
-Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
-{% macro _devanagari_char_row(chars, class) %}
-<div class="text-xl grid {{ class }}">
-{% for char in chars.split() %}
-  <button class="hover:bg-slate-100 rounded p-1">{{ char|safe }}</button>
-{% endfor %}
-</div>
-{% endmacro %}
-
-
-{# Editing toolbar. #}
-{% macro toolbar() %}
-<nav class="border my-2 rounded flex">
-  <div x-data="{open: false}" class="relative">
-    <button class="block p-2 hover:bg-slate-100"
-       @click.prevent="open=!open"
-       @click.outside="open=false">Layout</button>
-    <div x-show="open" class="dropdown-pane w-48">
-      <ul class="text-sm" @click.prevent="open=false">
-        {{ dropdown_item('displaySideBySide', 'Image right, text left') }}
-        {{ dropdown_item('displayTopAndBottom', 'Image above, text below') }}
-      </ul>
-    </div>
-  </div>
-
-  <div x-data="{open: false}" class="relative">
-    <button class="block p-2 hover:bg-slate-100"
-       @click.prevent="open=!open"
-       @click.outside="open=false">Mark text</button>
-    <div x-show="open" class="dropdown-pane w-48">
-      <ul class="text-sm" @click.prevent="open=false">
-        {{ dropdown_item('markAsError', 'Mark as error') }}
-        {{ dropdown_item('markAsFix', 'Mark as fix') }}
-        {{ dropdown_item('markAsUnclear', 'Mark as unclear') }}
-        {{ dropdown_item('markAsFootnoteNumber', 'Mark as footnote number') }}
-      </ul>
-    </div>
-  </div>
-
-  <div x-data="{open: false}" class="relative" @click.outside="open=false">
-    <button class="block p-2 hover:bg-slate-100"
-       @click.prevent="open=!open">Transliterate</button>
-    <div x-show="open" class="dropdown-pane w-64 p-2">
-      <div class="mb-2 flex justify-between">
-        <label>From:</label>
-        <select x-model="fromScript">
-          <option value="hk">Harvard-Kyoto</option>
-          <option value="itrans">ITRANS</option>
-        </select>
-      </div>
-
-      <div class="mb-2 flex justify-between">
-        <label>To:</label>
-        <select x-model="toScript">
-          <option value="devanagari">Devanagari</option>
-          <option value="iast">IAST</option>
-        </select>
-      </div>
-
-      <button class="mt-4 btn btn-basic block w-full"
-          @click.prevent="transliterate; open=false">
-          Transliterate selected text
-      </button>
-    </div>
-  </div>
-
-  <div x-data="{open: false}" class="relative">
-    <button class="block p-2 hover:bg-slate-100"
-       @click.prevent="open=!open"
-       @click.outside="open=false">Characters</button>
-    <div x-show="open" class="p-2 dropdown-pane w-60" @click.prevent="copyCharacter">
-      <p class="text-xs text-center mb-2">Click a character to copy it.</p>
-      <ul class="text-center">
-        {{ _latin_char_row('ā á â à', 'grid-cols-8') }}
-        {{ _latin_char_row('ī í î ì', 'grid-cols-8') }}
-        {{ _latin_char_row('ū ú û ù', 'grid-cols-8') }}
-        {{ _latin_char_row('ṛ ṝ ḷ ḹ', 'grid-cols-8') }}
-        {{ _latin_char_row('ē é ê è', 'grid-cols-8') }}
-        {{ _latin_char_row('ō ó ô ò', 'grid-cols-8') }}
-        {{ _latin_char_row('ḥ ṁ ṃ', 'grid-cols-6') }}
-        {{ _latin_char_row('ṅ ñ ṇ', 'grid-cols-6') }}
-        {{ _latin_char_row('ṭ ḍ ś ṣ ç', 'grid-cols-10') }}
-        {{ _devanagari_char_row('&#x0964; &#x0965; &#x093d; &#x0970; &#xa8f2; &#xa8f3;',
-            'grid-cols-6') }}
-      </ul>
-    </div>
-  </div>
-</nav>
-{% endmacro %}
+{% import "macros/components.html" as site_components %}
+{% import "proofing/pages/editor-components.html" as editor %}
 
 
 {% block title %}Edit: {{ project.title }}/{{ cur.slug }} | Ambuda{% endblock %}
@@ -157,7 +10,7 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
 {% block main %}
 <article class="p-4">
   {% if not current_user.is_authenticated %}
-  {% call components.p_warning() %}
+  {% call site_components.p_warning() %}
   {% set url = url_for('auth.register') %}
   Since you are not logged in, some functions (such as the OCR button) have
   been disabled. To use all website features, please <a class="underline"
@@ -165,9 +18,8 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
   {% endcall %}
   {% endif %}
 
-  {{ small_header(project, cur=cur, prev=prev, next=next) }}
-  {{ m.page_status(cur.status.name) }}
-  {{ components.flash_messages() }}
+  {{ editor.navigation_bar(project, cur=cur, prev=prev, next=next) }}
+  {{ site_components.flash_messages() }}
 
   {% if conflict %}
   <pre class="p-2 bg-slate-100 my-4">{{ conflict.content }}</pre>
@@ -177,45 +29,10 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
     {{ form.csrf_token }}
     {{ form.version }}
 
-    {{ toolbar() }}
+    {{ editor.menu_bar() }}
     <div :class="layoutClasses">
-      {# Text box #}
-      <div class="flex flex-col flex-1 border border-r-slate-400">
-        <div class="bg-slate-200 flex justify-between">
-          <div>
-            <button
-                type="button"
-                class="btn bg-sky-700 text-white m-2 hover:bg-sky-900"
-                @click="runOCR"
-                :disabled="isRunningOCR"
-                x-text="isRunningOCR ? 'Running ...' : 'Run OCR'">
-              Run OCR
-            </button>
-          </div>
-          <div>
-            {{ alpine_button("A<sup>+</sup>", "increaseTextSize") }}
-            {{ alpine_button("A<sup>-</sup>", "decreaseTextSize") }}
-          </div>
-        </div>
-        <textarea id="content" name="content" required=""
-          class="grow p-2 md:p-4 w-full resize-none"
-          :style="`font-size: ${textZoom}rem`"
-          @change="hasUnsavedChanges = true">{{ form.content.data or "" }}</textarea>
-      </div>
-
-      {# Raw image. #}
-      <div class="flex flex-col flex-1 border bg-slate-100">
-        <div class="bg-slate-200">
-          {{ alpine_button("&#x1f50d;<sup>+</sup>", "increaseImageZoom") }}
-          {{ alpine_button("&#x1f50d;&#x00b0;", "resetImageZoom") }}
-          {{ alpine_button("&#x1f50d;<sup>-</sup>", "decreaseImageZoom") }}
-          {{ osd_button("osd-rotate-left", "&#x27f2;") }}
-          {{ osd_button("osd-rotate-right", "&#x27f3;") }}
-        </div>
-
-        <div id="osd-image" class="grow">
-        </div>
-      </div>
+      {{ editor.text_box(form.content.data or "") }}
+      {{ editor.image_box() }}
     </div>
 
     <div class="p-4 mt-4 bg-slate-200">

--- a/ambuda/templates/proofing/pages/editor-components.html
+++ b/ambuda/templates/proofing/pages/editor-components.html
@@ -8,7 +8,7 @@ these components in our help text and documentation.
 
 
 {# Button for specific OpenSeadragon (OSD) functions. #}
-{# FIXME: migrate all of these buttons to `alpine_button`. #} 
+{# FIXME: migrate all of these buttons to `alpine_button`. #}
 {% macro osd_button(id, text) %}
 <button type="button" id="{{ id }}" class="p-2 hover:bg-slate-300">{{ text|safe }}</button>
 {% endmacro %}

--- a/ambuda/templates/proofing/pages/editor-components.html
+++ b/ambuda/templates/proofing/pages/editor-components.html
@@ -1,0 +1,224 @@
+{# Components of the page editor.
+
+We use these macros both to keep `pages/edit` readable and so that we can embed
+these components in our help text and documentation.
+#}
+
+{% import "macros/proofing.html" as m %}
+
+
+{# Button for specific OpenSeadragon (OSD) functions. #}
+{# FIXME: migrate all of these buttons to `alpine_button`. #} 
+{% macro osd_button(id, text) %}
+<button type="button" id="{{ id }}" class="p-2 hover:bg-slate-300">{{ text|safe }}</button>
+{% endmacro %}
+
+
+{# A generic application button. #}
+{% macro alpine_button(text, click) %}
+<button type="button" class="p-2 hover:bg-slate-300" @click="{{ click }}">
+  {{ text|safe }}
+</button>
+{% endmacro %}
+
+
+{# A small status badge we display in the page header. #}
+{% macro status_badge(status) %}
+{% if status == 'reviewed-0' %}
+<span class="p-1 rounded text-xs {{ m.revision_colors(status) }}">Needs more work</span>
+{% elif status == 'reviewed-1' %}
+<span class="p-1 rounded text-xs {{ m.revision_colors(status) }}">Proofread once</span>
+{% elif status == 'reviewed-2' %}
+<span class="p-1 rounded text-xs {{ m.revision_colors(status) }}">Proofread twice</span>
+{% elif status == 'skip' %}
+<span class="p-1 rounded text-xs {{ m.revision_colors(status) }}">Not relevant</span>
+{% endif %}
+{% endmacro %}
+
+
+{# Page information and navigation options. #}
+{% macro navigation_bar(project, cur, prev, next) %}
+<header class="py-2 a-hover-underline">
+  <div class="flex justify-between items-center">
+  <h1 class="text pr-4">
+    <a class="text-black font-bold"
+        href="{{ url_for("proofing.project.summary", slug=project.slug) }}">
+       {{ project.title }}</a>
+    / {{ cur.slug }}
+  </h1>
+
+  {% set history_url = url_for("proofing.page.history", project_slug=project.slug, page_slug=cur.slug) %}
+  <nav class="flex text-slate-700 text-md">
+    <a class="block p-2" href="{{ history_url }}">History</a>
+    {% set prev_url = url_for('proofing.page.edit', project_slug=project.slug, page_slug=prev.slug) %}
+    {% set next_url = url_for('proofing.page.edit', project_slug=project.slug, page_slug=next.slug) %}
+    <a class="block p-2" href="{{ prev_url }}">&larr;</a>
+    <a class="block p-2" href="{{ next_url }}">&rarr;</a>
+  </nav>
+  </div>
+  {{ status_badge(cur.status.name) }}
+</header>
+{% endmacro %}
+
+
+{# Defines an item in a dropdown menu. #}
+{% macro _dropdown_item(fn, text) %}
+<li>
+  <button class="dropdown-item" @click.prevent="{{ fn }}">{{ text|safe }}</button>
+</li>
+{% endmacro %}
+
+
+{#
+Print a row of Latin characters.
+Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
+{% macro _latin_char_row(chars, class) %}
+<div class="grid {{ class }}">
+{% for char in chars.split() %}
+  <button class="hover:bg-slate-100 rounded p-1">{{ char.upper()|safe }}</button>
+  <button class="hover:bg-slate-100 rounded p-1">{{ char|safe }}</button>
+{% endfor %}
+</div>
+{% endmacro %}
+
+
+{#
+Print a row of Devanagari characters.
+Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
+{% macro _devanagari_char_row(chars, class) %}
+<div class="text-xl grid {{ class }}">
+{% for char in chars.split() %}
+  <button class="hover:bg-slate-100 rounded p-1">{{ char|safe }}</button>
+{% endfor %}
+</div>
+{% endmacro %}
+
+
+{# Toolbar with various options and dropdowns. #}
+{% macro menu_bar() %}
+{% set button_css = "block p-2 hover:bg-slate-100" %}
+<nav class="border my-2 rounded flex">
+  <div x-data="{open: false}" class="relative">
+    <button class="{{ button_css }}"
+       @click.prevent="open=!open"
+       @click.outside="open=false">Layout</button>
+    <div x-show="open" class="dropdown-pane w-48">
+      <ul class="text-sm" @click.prevent="open=false">
+        {{ _dropdown_item('displaySideBySide', 'Image right, text left') }}
+        {{ _dropdown_item('displayTopAndBottom', 'Image above, text below') }}
+      </ul>
+    </div>
+  </div>
+
+  <div x-data="{open: false}" class="relative">
+    <button class="{{ button_css }}"
+       @click.prevent="open=!open"
+       @click.outside="open=false">Markup</button>
+    <div x-show="open" class="dropdown-pane w-48">
+      <ul class="text-sm" @click.prevent="open=false">
+        {{ _dropdown_item('markAsError', 'Mark as error') }}
+        {{ _dropdown_item('markAsFix', 'Mark as fix') }}
+        {{ _dropdown_item('markAsUnclear', 'Mark as unclear') }}
+        {{ _dropdown_item('markAsFootnoteNumber', 'Mark as footnote number') }}
+      </ul>
+    </div>
+  </div>
+
+  <div x-data="{open: false}" class="relative" @click.outside="open=false">
+    <button class="{{ button_css }}"
+       @click.prevent="open=!open">Transliterator</button>
+    <div x-show="open" class="dropdown-pane w-64 p-2">
+      <div class="mb-2 flex justify-between">
+        <label>From:</label>
+        <select x-model="fromScript">
+          <option value="hk">Harvard-Kyoto</option>
+          <option value="itrans">ITRANS</option>
+        </select>
+      </div>
+
+      <div class="mb-2 flex justify-between">
+        <label>To:</label>
+        <select x-model="toScript">
+          <option value="devanagari">Devanagari</option>
+          <option value="iast">IAST</option>
+        </select>
+      </div>
+
+      <button class="mt-4 btn btn-basic block w-full"
+          @click.prevent="transliterate; open=false">
+          Transliterate selected text
+      </button>
+    </div>
+  </div>
+
+  <div x-data="{open: false}" class="relative">
+    <button class="{{ button_css }}"
+       @click.prevent="open=!open"
+       @click.outside="open=false">Characters</button>
+    <div x-show="open" class="p-2 dropdown-pane w-60" @click.prevent="copyCharacter">
+      <p class="text-xs text-center mb-2">Click a character to copy it.</p>
+      <ul class="text-center">
+        {{ _latin_char_row('ā á â à', 'grid-cols-8') }}
+        {{ _latin_char_row('ī í î ì', 'grid-cols-8') }}
+        {{ _latin_char_row('ū ú û ù', 'grid-cols-8') }}
+        {{ _latin_char_row('ṛ ṝ ḷ ḹ', 'grid-cols-8') }}
+        {{ _latin_char_row('ē é ê è', 'grid-cols-8') }}
+        {{ _latin_char_row('ō ó ô ò', 'grid-cols-8') }}
+        {{ _latin_char_row('ḥ ṁ ṃ', 'grid-cols-6') }}
+        {{ _latin_char_row('ṅ ñ ṇ', 'grid-cols-6') }}
+        {{ _latin_char_row('ṭ ḍ ś ṣ ç', 'grid-cols-10') }}
+        {{ _devanagari_char_row('&#x0964; &#x0965; &#x093d; &#x0970; &#xa8f2; &#xa8f3;',
+            'grid-cols-6') }}
+      </ul>
+    </div>
+  </div>
+
+  <a class="{{ button_css }}"
+      href="{{ url_for('proofing.editor_guide') }}" target="_blank">Help</a> 
+</nav>
+{% endmacro %}
+
+
+{# Plain text box #}
+{% macro text_box(data) %}
+<div class="flex flex-col flex-1 border border-r-slate-400">
+  <div class="bg-slate-200 flex justify-between">
+    <div>
+      <button
+          type="button"
+          class="btn bg-sky-700 text-white m-2 hover:bg-sky-900"
+          @click="runOCR"
+          :disabled="isRunningOCR"
+          x-text="isRunningOCR ? 'Running ...' : 'Run OCR'">
+        Run OCR
+      </button>
+    </div>
+    <div>
+      {{ _alpine_button("A<sup>+</sup>", "increaseTextSize") }}
+      {{ _alpine_button("A<sup>-</sup>", "decreaseTextSize") }}
+    </div>
+  </div>
+  <textarea id="content" name="content" required=""
+    class="grow p-2 md:p-4 w-full resize-none"
+    :style="`font-size: ${textZoom}rem`"
+    @change="hasUnsavedChanges = true">{{ data }}</textarea>
+</div>
+{% endmacro %}
+
+
+{# Raw image viewer #}
+{% macro image_box() %}
+<div class="flex flex-col flex-1 border bg-slate-100">
+  <div class="bg-slate-200">
+    {{ alpine_button("&#x1f50d;<sup>+</sup>", "increaseImageZoom") }}
+    {{ alpine_button("&#x1f50d;&#x00b0;", "resetImageZoom") }}
+    {{ alpine_button("&#x1f50d;<sup>-</sup>", "decreaseImageZoom") }}
+    {{ osd_button("osd-rotate-left", "&#x27f2;") }}
+    {{ osd_button("osd-rotate-right", "&#x27f3;") }}
+  </div>
+
+  <div id="osd-image" class="grow">
+  </div>
+</div>
+{% endmacro %}
+

--- a/ambuda/templates/proofing/pages/editor-components.html
+++ b/ambuda/templates/proofing/pages/editor-components.html
@@ -194,8 +194,8 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
       </button>
     </div>
     <div>
-      {{ _alpine_button("A<sup>+</sup>", "increaseTextSize") }}
-      {{ _alpine_button("A<sup>-</sup>", "decreaseTextSize") }}
+      {{ alpine_button("A<sup>+</sup>", "increaseTextSize") }}
+      {{ alpine_button("A<sup>-</sup>", "decreaseTextSize") }}
     </div>
   </div>
   <textarea id="content" name="content" required=""

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -69,19 +69,19 @@ def index():
     )
 
 
-@bp.route("/beginners-guide")
+@bp.route("/help/beginners-guide")
 def beginners_guide():
     """Display our minimal proofing guidelines."""
     return render_template("proofing/beginners-guide.html")
 
 
-@bp.route("/complete-guide")
+@bp.route("/help/complete-guide")
 def complete_guide():
     """Display our complete proofing guidelines."""
     return render_template("proofing/complete-guidelines.html")
 
 
-@bp.route("/editor-guide")
+@bp.route("/help/editor-guide")
 def editor_guide():
     """Describe how to use the page editor."""
     return render_template("proofing/editor-guide.html")

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -81,6 +81,12 @@ def complete_guide():
     return render_template("proofing/complete-guidelines.html")
 
 
+@bp.route("/editor-guide")
+def editor_guide():
+    """Describe how to use the page editor."""
+    return render_template("proofing/editor-guide.html")
+
+
 @bp.route("/create-project", methods=["GET", "POST"])
 @login_required
 def create_project():

--- a/ambuda/views/proofing/page.py
+++ b/ambuda/views/proofing/page.py
@@ -39,7 +39,7 @@ class EditPageForm(FlaskForm):
     status = SelectField(
         "Status",
         choices=[
-            ("reviewed-0", "Unreviewed"),
+            ("reviewed-0", "Needs more work"),
             ("reviewed-1", "Proofread once"),
             ("reviewed-2", "Proofread twice"),
             ("skip", "No useful text"),

--- a/test/ambuda/views/proofing/test_main.py
+++ b/test/ambuda/views/proofing/test_main.py
@@ -23,12 +23,12 @@ def test_index(client):
 
 
 def test_beginners_guide(client):
-    resp = client.get("/proofing/beginners-guide")
+    resp = client.get("/proofing/help/beginners-guide")
     assert "Beginner's guide" in resp.text
 
 
 def test_complete_guide(client):
-    resp = client.get("/proofing/complete-guide")
+    resp = client.get("/proofing/help/complete-guide")
     assert "Proofing guidelines" in resp.text
 
 


### PR DESCRIPTION
The page editor has become much more complex. This page describes how to
use it and what features it has available.

In addition, I moved all of our help pages to be under `/proofing/help`. I did so
because I had a local Flask error where Flask thought `editor-guide` was
a project slug and attempted to load the `project.summary` route
instead. (The error was resolved by using `/editor-guide2` or
`/editor-guide3`, but `/editor-guide` specifically fails. I'm not sure
why.) This issue suggests two potential problems going forward:

1. We should be careful about adding new slugs to the `proofing`
   namespace since they can interact strangely with `project.summary`.

2. In fact, we should probably just namespace projects under a new
   `projects` prefix. This is also avoids a potential issue where a new
   project has the same slug as a toplevel page like `/beginners-guide`.

For (1), I'm moving these under `help`. I'll consider (2) going forward.

Test plan: loaded the page. I considered embedding richer versions of
the menu bar so that the user could experiment with its JS, but that
produces some quite strong coupling between a simple help page and the
underlying JS logic, which seems excessive to me right now.