### PR TITLE
Fix a seed script error and 500 error

### DIFF
--- a/ambuda/seed/dcs.py
+++ b/ambuda/seed/dcs.py
@@ -64,8 +64,8 @@ def iter_parse_data(path: Path):
                     xml_id = value
                     _, _, block_slug = xml_id.partition(".")
             elif line:
-                if line.count("\t") != 3:
-                    raise ValueError(f'Line "{line}" must have exactly three fields.')
+                if line.count("\t") != 2:
+                    raise ValueError(f'Line "{line}" must have exactly two tabs.')
                 buf.append(line)
             else:
                 yield block_slug, "\n".join(buf)

--- a/ambuda/utils/cheda.py
+++ b/ambuda/utils/cheda.py
@@ -60,6 +60,7 @@ LAKARAS = {
     "lrt": "simple future",
     "lot": "imperative",
     "lan": "imperfect",
+    "lan_unaug": "imperfect (unaugmented)",
     "vidhilin": "optative",
     "ashirlin": "benedictive",
     "lun": "aorist",

--- a/test/ambuda/utils/test_parsing.py
+++ b/test/ambuda/utils/test_parsing.py
@@ -11,6 +11,10 @@ from ambuda.utils.cheda import readable_parse
         ("pos=va,g=n,c=3,n=p", "participle, neuter instrumental plural"),
         ("pos=v,p=3,n=s,l=lat", "verb, third-person singular present"),
         ("pos=v,p=2,n=s,l=ashirlin", "verb, second-person singular benedictive"),
+        (
+            "pos=v,p=3,n=s,l=lan_unaug",
+            "verb, third-person singular imperfect (unaugmented)",
+        ),
         ("pos=n,g=m,comp=y", "noun, compounded"),
         ("pos=i", "indeclinable"),
     ],


### PR DESCRIPTION
- Seed script should check for exactly 3 fields, not exactly 3 `\t`
  characters. (Fixes #255)
- `cheda` should also recognize `lan_unaug`

Test plan: unit tests and ran the seed script.