### PR TITLE
Add cache busting for CSS and JS assets

### DIFF
--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -22,6 +22,7 @@ from ambuda import database
 from ambuda import filters
 from ambuda import queries
 from ambuda.mail import mailer
+from ambuda.utils import assets
 from ambuda.views.about import bp as about
 from ambuda.views.auth import bp as auth
 from ambuda.views.api import bp as api
@@ -123,5 +124,6 @@ def create_app(config_env: str):
             "time_ago": filters.time_ago,
         }
     )
+    app.jinja_env.globals.update({"asset": assets.hashed_static})
 
     return app

--- a/ambuda/templates/base.html
+++ b/ambuda/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="description" content="{% block meta_description -%}
     A breakthrough Sanskrit library. Read our library of traditional Sanskrit texts with word-by-word analysis, integrated dictionary support, and so much more.
     {%- endblock %}">
-    <link rel="stylesheet" type="text/css" href="/static/gen/style.css?v=12">
+    <link rel="stylesheet" type="text/css" href="{{ asset('gen/style.css') }}">
     <link rel="icon" href="data:,">
     <title>{% block title %}{% endblock %}</title>
     {% block scripts %}{% endblock %}

--- a/ambuda/templates/header-main-footer.html
+++ b/ambuda/templates/header-main-footer.html
@@ -6,7 +6,7 @@
     <script async defer data-domain="ambuda.org" src="https://plausible.io/js/plausible.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/@indic-transliteration/sanscript@1.2.7/sanscript.min.js"></script>
     {# Load scripts before Alpine so that our init hooks are properly set up. #}
-    <script defer src="/static/gen/main.js?v=3"></script>
+    <script defer src="{{ asset('gen/main.js') }}"></script>
     <script src="https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js" defer></script>
 {% endblock %}
 

--- a/ambuda/templates/proofing/pages/editor-components.html
+++ b/ambuda/templates/proofing/pages/editor-components.html
@@ -131,6 +131,7 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
       <div class="mb-2 flex justify-between">
         <label>From:</label>
         <select x-model="fromScript">
+          <option value="hk">OPTITRANS (anka - अङ्क)</option>
           <option value="hk">Harvard-Kyoto</option>
           <option value="itrans">ITRANS</option>
         </select>

--- a/ambuda/templates/proofing/pages/editor-components.html
+++ b/ambuda/templates/proofing/pages/editor-components.html
@@ -131,7 +131,6 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
       <div class="mb-2 flex justify-between">
         <label>From:</label>
         <select x-model="fromScript">
-          <option value="hk">OPTITRANS (anka - अङ्क)</option>
           <option value="hk">Harvard-Kyoto</option>
           <option value="itrans">ITRANS</option>
         </select>

--- a/ambuda/utils/assets.py
+++ b/ambuda/utils/assets.py
@@ -14,7 +14,8 @@ def hashed_static(filename: str) -> str:
     """Add cache busting for asset URLs.
 
     We append a small hash prefix that represents the asset's content. The
-    `functools.cache` decorator calls this function at most once per deploy.
+    `functools.cache` decorator memoizes the function, and a s a result, we
+    hash the given asset file at most once per worker deploy.
     """
     asset_path = STATIC_DIR / filename
     try:

--- a/ambuda/utils/assets.py
+++ b/ambuda/utils/assets.py
@@ -1,0 +1,24 @@
+import functools
+import hashlib
+from pathlib import Path
+
+from flask import url_for
+
+
+STATIC_DIR = Path(__file__).parent.parent / "static"
+assert STATIC_DIR.exists()
+
+
+@functools.cache
+def hashed_static(filename: str) -> str:
+    """Add cache busting for asset URLs.
+
+    We append a small hash prefix that represents the asset's content. The
+    `functools.cache` decorator calls this function at most once per deploy.
+    """
+    asset_path = STATIC_DIR / filename
+    content = asset_path.read_bytes()
+    hash_prefix = hashlib.md5(content).hexdigest()[:7]
+
+    base_url = url_for("static", filename=filename)
+    return f"{base_url}?h={hash_prefix}"

--- a/ambuda/utils/assets.py
+++ b/ambuda/utils/assets.py
@@ -17,7 +17,12 @@ def hashed_static(filename: str) -> str:
     `functools.cache` decorator calls this function at most once per deploy.
     """
     asset_path = STATIC_DIR / filename
-    content = asset_path.read_bytes()
+    try:
+        content = asset_path.read_bytes()
+    except FileNotFoundError:
+        # If the content is missing, use an empty string to prevent a 500
+        # error.
+        content = b""
     hash_prefix = hashlib.md5(content).hexdigest()[:7]
 
     base_url = url_for("static", filename=filename)


### PR DESCRIPTION
Cache busting means that when we update a file like `main.js`, we modify
the `main.js` URL in such a way that all users will fetch a new version
of the file. Without cache busting, users will use a stale version that
could be either degraded or broken.

Our URL scheme appends a simple query parameter based on a hash of the
asset's content.  On dev, these URLs have no effect. On prod, we will
hash the asset content at most once per application startup.

(A common cache busting solution is `webassets` via the Flask-Assets
package. But `webassets` doesn't cleanly interact with our live Tailwind
and esbuild watchers, which is why I avoid it here.)

Test plan: examined the generated URLs on the devserver.

(Fixes #62.)