### PR TITLE
Remove spell check for Devanagari

### DIFF
--- a/ambuda/templates/proofing/pages/editor-components.html
+++ b/ambuda/templates/proofing/pages/editor-components.html
@@ -201,7 +201,7 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
   <textarea id="content" name="content" required=""
     class="grow p-2 md:p-4 w-full resize-none"
     :style="`font-size: ${textZoom}rem`"
-    @change="hasUnsavedChanges = true">{{ data }}</textarea>
+    @change="hasUnsavedChanges = true" spellcheck="false">{{ data }}</textarea>
 </div>
 {% endmacro %}
 


### PR DESCRIPTION
Added `spellcheck=false` attribute to `<textarea>` to disable
spellcheck. Fixes #242 