### PR TITLE
Fix headings on support page

### DIFF
--- a/ambuda/templates/support.html
+++ b/ambuda/templates/support.html
@@ -119,8 +119,6 @@ url }}">our new proofreading tool</a> to transcribe and proofread these texts.
   <li>Supporting and moderating our proofreading community as a whole.</li>
 </ul>
 
-  
-</div>
 
 {{ _h('contribute_text') }}
 <div class="prose">
@@ -133,6 +131,8 @@ url }}">our new proofreading tool</a> to transcribe and proofread these texts.
 
 
 {{ _h('tagging') }}
+</div>
+
 <section class="p-4 my-4 bg-slate-100 a-underline">
 <p>We're still setting up the workflow here. Please check back soon.</p>
 </section>


### PR DESCRIPTION
At least one heading was rendered as ordinary text since it was outside
of the `prose` context.

Test plan: loaded the page on dev.