### PR TITLE
Revise various proofing docs

### DIFF
--- a/ambuda/templates/macros/proofing-guides.html
+++ b/ambuda/templates/macros/proofing-guides.html
@@ -1,0 +1,73 @@
+{% import "macros/proofing.html" as m %}
+{% import "proofing/pages/editor-components.html" as editor %}
+
+
+{# Show a button icon inline. #}
+{% macro _button(text) %}<span class="p-1 bg-slate-200">{{ text|safe }}</span>{% endmacro %}
+
+
+{# Embed an HTML widget as a figure. #}
+{% macro html_figure(caption) %}
+<figure class="my-12">
+  <div class="border p-4">
+    {{ caller() }}
+  </div>
+  <figcaption class="text-sm text-slate-600 mt-2 text-center">{{ caption }}</figcaption>
+</figure>
+{% endmacro %}
+
+
+{% macro text_box() %}
+<div class="border flex-1">
+  <div class="bg-slate-200 flex justify-between">
+    <div>
+      <button type="button" class="btn bg-sky-700 text-white m-2 hover:bg-sky-900">
+        Run OCR
+      </button>
+    </div>
+    <div>
+      {{ editor.alpine_button("A<sup>+</sup>", "increaseTextSize") }}
+      {{ editor.alpine_button("A<sup>-</sup>", "decreaseTextSize") }}
+    </div>
+  </div>
+  <textarea id="content" name="content" required=""
+    class="grow p-2 md:p-4 w-full resize-none h-32">{{ data }}</textarea>
+</div>
+{% endmacro %}
+
+
+{% macro image_viewer() %}
+<div class="flex flex-col flex-1 border bg-slate-100 border">
+  <div class="bg-slate-200">
+    {{ editor.alpine_button("&#x1f50d;<sup>+</sup>", "") }}
+    {{ editor.alpine_button("&#x1f50d;&#x00b0;", "") }}
+    {{ editor.alpine_button("&#x1f50d;<sup>-</sup>", "") }}
+    {{ editor.osd_button("osd-rotate-left", "&#x27f2;") }}
+    {{ editor.osd_button("osd-rotate-right", "&#x27f3;") }}
+  </div>
+
+  <div id="osd-image" class="h-32"></div>
+</div>
+{% endmacro %}
+
+
+{% macro submission_form() %}
+<div class="p-4 mt-4 bg-slate-200">
+  <label class="text-slate-600 mb-2 block">Summary of changes made</label>
+  <input type="text" class="block rounded bg-white w-full mb-4 p-2"></input>
+
+  <label class="text-slate-600 mb-2 block">Status</label>
+  <select class="block rounded bg-white w-full mb-4 p-2">
+    <option>Needs more work</option>
+    <option>Proofread once</option>
+    <option>Proofread twice</option>
+    <option>No useful text</option>
+  </select>
+
+  {% set cc0 = "https://creativecommons.org/publicdomain/zero/1.0/" %}
+  <p class="my-4 text-sm">By saving your changes, you agree to release your
+  contribution under the <a class="underline" href="{{ cc0 }}">CC0 (public
+  domain) license</a>.</p>
+  <a href="#" class="inline-block btn btn-submit" type="submit">Publish changes</a>
+</div>
+{% endmacro %}

--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -3,8 +3,8 @@
 
 {% macro title_and_subtitle(title, subtitle = none) %}
 <header class="mb-4">
-  <h1 class="font-bold text-3xl">{{ title|safe }}</h1>
-  {% if subtitle %}<p class="mt-1 text-slate-500">{{ subtitle|safe }}</p>{% endif %}
+  <h1 class="font-bold text-4xl">{{ title|safe }}</h1>
+  {% if subtitle %}<p class="mt-1 text-lg text-slate-500">{{ subtitle|safe }}</p>{% endif %}
 </header>
 {% endmacro %}
 

--- a/ambuda/templates/proofing/beginners-guide.html
+++ b/ambuda/templates/proofing/beginners-guide.html
@@ -1,6 +1,7 @@
 {% extends 'proofing/base-sidebar.html' %}
 {% import "macros/components.html" as components %}
 {% import "macros/proofing.html" as m %}
+{% import "macros/proofing-guides.html" as m_guide %}
 
 
 {% set contents = {
@@ -30,9 +31,11 @@
 
 
 {% block content %}
-<div class="prose">
-<h1>Beginner's guide to proofing</h1>
+{{ m.title_and_subtitle(
+    "Beginner's guide",
+    "A five minute guide to proofing Sanskrit texts") }}
 
+<div class="prose">
 <p><dfn>Proofing</dfn>, short for "proofreading," is when people like you create
 high-quality Sanskrit text that everyone can use and enjoy. All of our proofing
 projects are based on scans of physical books.
@@ -44,9 +47,9 @@ projects are based on scans of physical books.
 
 {% set index = url_for('proofing.index') %}
 {% set create = url_for('proofing.create_project') %}
-<p>You can see all of our active projects on our <a href="{{ index }}">main
-    page</a>. Each of these projects has a progress bar that shows the status of
-each of its pages:
+<p>You can see all of our active projects on our <a href="{{ index }}">ongoing
+projects</a> page. Each project has a progress bar that shows what work has
+been done on its pages so far:</p>
 
 <ul>
   <li><p><dfn class="p-0.5 bg-gray-200">gray</dfn> means that the page is not
@@ -54,21 +57,20 @@ each of its pages:
       pages, and so on.</li>
 
   <li><p><dfn class="p-0.5 bg-red-200">red</dfn> means that nobody has
-      fully proofread the page.</li>
+      fully proofed the page.</li>
 
   <li><p><dfn class="p-0.5 bg-yellow-200">yellow</dfn> means that one person
-      has fully proofread the page and that the page is ready for a second
-      proofreader to review it.</li>
+      has fully proofed the page and that the page is ready for a second
+      proofer to review it.</li>
 
   <li><p><dfn class="p-0.5 bg-green-200">green</dfn> means that two people have
-      fully proofread the page. We recommend that you check some of our green
+      fully proofed the page. We recommend that you check some of our green
       pages to get a sense of what kinds of results we're aiming for.</li>
 </ul>
 
 <p>If you don't see a book you want to work on, you can <a href="{{ create
-    }}">create a new project</a> instead. We are open to any book that is
-in the public domain and related to Sanskrit in some way. But to avoid wasting
-effort, please also search online to see if your book has already been digitized.
+}}">create a project</a> instead. We are open to any book that is in the public
+domain and related to Sanskrit in some way.</p>
 
 
 {{ _h('how-to-proof') }}
@@ -79,11 +81,18 @@ pages. We recommend starting with a <span class="p-0.5 bg-red-200
 
 <p>Our page editor shows a basic side-by-side view:
 
-<p class="bg-red-300 p-2">Image coming soon</p>
+{% call m_guide.html_figure("Our page editor. This example doesn't display any
+image on the right-hand side. On a real page, the right side will display a
+page from some Sanskrit text.") %}
+<div class="flex flex-row">
+{{ m_guide.text_box() }}
+{{ m_guide.image_viewer() }}
+</div>
+{% endcall %}
 
 <p>The right side has the original page, and the left side has a text box where
 you can type your changes. The left side also has an <span class="p-1
-    bg-slate-100">OCR</span> button that automatically transcribes a page.
+    bg-slate-100">OCR</span> button that automatically transcribes the page.
 
 <p>Your goal is to match the text in the original scan as accurately as
 possible. We strongly recommend running OCR first then fixing its mistakes by
@@ -91,13 +100,17 @@ hand.
 
 <p>When you're ready to save your changes, you can use the form at the bottom
 of the page editor:
+</div>
 
-<p class="bg-red-300 p-2">Image coming soon</p>
+{% call m_guide.html_figure("The submission form") %}
+{{ m_guide.submission_form() }}
+{% endcall %}
 
+<div class="prose">
 <p>If your change is complex, feel free to write a short message about what
 changes you made. Otherwise, you can leave this blank.
 
-<p>More importantly, you can change the page's status so that other proofreaders
+<p>More importantly, you can change the page's status so that other proofers
 know what work still needs to be done on the page.
 
 
@@ -106,7 +119,7 @@ know what work still needs to be done on the page.
 
 {% call components.div_note() %}
 {% set url = url_for("proofing.complete_guide") %}
-<p class="prose">For much more detail, see our <a href="{{ url }}">full
+<p class="prose">For much more detail, see our <a href="{{ url }}">complete
     guidelines</a>.</p>
 {% endcall %}
 
@@ -122,7 +135,7 @@ pixel-perfect copy of the original image.
       please write {{ 'kAryyate'|d }} and not {{ 'kAryate'|d }}. Our goal is to
       transcribe the text, not to edit it.</li>
   <li><p>hyphens and line breaks, if they appear in the original text. Hyphens
-      and line breaks help proofreaders quickly compare a specific line against
+      and line breaks help proofers quickly compare a specific line against
       the original page, and we can easily remove them later on.</li>
 </ul>
 
@@ -133,10 +146,10 @@ pixel-perfect copy of the original image.
       edition, so we can exclude them.</li>
   <li><p>any content that is not part of the original book. This includes:
       handwritten notes, stamps, watermarks, dirt, stains, etc.</li>
-  <li><p>word splitting ({{ 'padaccheda'|d }}) or sandhi splitting ({{
-      'sandhivigraha'|d }}) of any kind. If the original book says {{
-      'kazca'|d }}, please write {{ 'kazca'|d }} and not {{ 'kaz ca'|d }} or {{
-      'kaH ca'|d }}.
+  <li><p>extra word splitting ({{ 'padaccheda'|d }}) or sandhi splitting ({{
+      'sandhivigraha'|d }}) of any kind. If the original book says {{ 'kazca'|d
+      }}, please write {{ 'kazca'|d }} and not {{ 'kaz ca'|d }} or {{ 'kaH
+      ca'|d }}.
   </li>
   <li><p>transliterations of the original text. If the original text says {{
       'narasya'|d }}, please write {{ 'narasya'|d }} and not <i>{{
@@ -160,14 +173,30 @@ pixel-perfect copy of the original image.
 
 <h3>How should I handle typos and mistakes?</h3>
 
-<p>Our job is to capture the text as-is. If you believe the text has an error,
-wrap the error in <kbd>&lt;error&gt;&lt;/error&gt;</kbd> tags like so:
+<p>Our job is to capture the text as-is. If you see an error, please do the
+following:</p>
 
-<pre class="bg-slate-100 p-2 my-4">
-This is an &lt;error&gt;exampel&lt;/error&gt; of an error.
-</pre>
+<ol>
+  <li>Highlight the error.</li>
+  <li>Select <kbd>Markup &rarr; Mark as error</kbd> from the menu bar.</li>
+</ol>
 
-<p>Once the page is proofread and ready for publishing, a specialist will
+<p>If you are very sure how to fix the error, please do the following:
+
+<ol>
+  <li>Write your fix next to the error.</li>
+  <li>Highlight your fix.</li>
+  <li>Select <kbd>Markup &rarr; Mark as fix</kbd> from the menu bar.</li>
+</ol>
+
+<p>If you cannot understand what the source text says, please do the following:
+
+<ol>
+  <li>Highlight the unclear text.</li>
+  <li>Select <kbd>Markup &rarr; Mark as unclear</kbd> from the menu bar.</li>
+</ol>
+
+<p>Once the page is proofed and ready for publishing, a specialist will
 examine each of these errors and decide how to handle them.
 
 {% set discord_url = "https://discord.gg/7rGdTyWY7Z" %}
@@ -175,7 +204,7 @@ examine each of these errors and decide how to handle them.
 <h3>What if I still have questions?</h3>
 
 <p>Please <a href="{{ discord_url }}">join our Discord server</a> and ask your
-question on our <kbd>#proofreading</kbd> channel! We are friendly, responsive,
+question on our <kbd>#proofing</kbd> channel! We are friendly, responsive,
 and deeply grateful for your help.</p>
 
 </ul>

--- a/ambuda/templates/proofing/complete-guide.html
+++ b/ambuda/templates/proofing/complete-guide.html
@@ -82,9 +82,12 @@
 
 
 {% block content %}
-<div class="prose">
-<h1>Complete guide to proofing</h1>
+{{ m.title_and_subtitle(
+    "Complete guide",
+    "Comprehensive guidelines for proofing a text. And when in doubt:
+    don't change what the page says!") }}
 
+<div class="prose">
 <p>This document defines the proofreading guidelines we use on Ambuda.
 Generally, these guidelines apply to all of the projects we proof.
 

--- a/ambuda/templates/proofing/create-project-post.html
+++ b/ambuda/templates/proofing/create-project-post.html
@@ -28,7 +28,7 @@
     const url = `/proofing/status/${taskId}`;
     const resp = await fetch(url);
     const progress = await resp.text();
-    $('#progress').innerHTML = progress;
+    document.querySelector('#progress').innerHTML = progress;
   }, 5000);
 </script>
 

--- a/ambuda/templates/proofing/create-project.html
+++ b/ambuda/templates/proofing/create-project.html
@@ -13,10 +13,11 @@
 
 
 {% block content %}
+{{ m.title_and_subtitle(
+    "Create a project",
+    "Use our simple uploader to create a new proofing project.") }}
 
 <div class="prose">
-<h1>Create project</h1>
-
 <p>Please upload a PDF file of the original text.</p>
 </div>
 

--- a/ambuda/templates/proofing/editor-guide.html
+++ b/ambuda/templates/proofing/editor-guide.html
@@ -1,6 +1,7 @@
 {% extends 'proofing/base-sidebar.html' %}
 {% import "macros/components.html" as components %}
 {% import "macros/proofing.html" as m %}
+{% import "macros/proofing-guides.html" as m_guide %}
 {% import "proofing/pages/editor-components.html" as editor %}
 
 
@@ -8,33 +9,24 @@
 {% macro _button(text) %}<span class="p-1 bg-slate-200">{{ text|safe }}</span>{% endmacro %}
 
 
-{# Embed an HTML widget as a figure. #}
-{% macro html_figure(caption) %}
-<figure class="my-12">
-  <div class="border p-4">
-    {{ caller() }}
-  </div>
-  <figcaption class="text-sm text-slate-600 mt-2 text-center">{{ caption }}</figcaption>
-</figure>
-{% endmacro %}
-
-
-{% block title %}How to use the page editor | Ambuda{% endblock %}
+{% block title %}Editor manual| Ambuda{% endblock %}
 
 
 {% block sidebar %}{{ m.main_nav('manual') }}{% endblock %}
 
 
 {% block content %}
-<div class="prose">
-<h1>How to use the page editor</h1>
+{{ m.title_and_subtitle(
+    "Editor manual",
+    "Detailed notes (if you want them) on how to use our page editor") }}
 
+<div class="prose">
 <p>Our simple and powerful <dfn>page editor</dfn> makes it easy to proofread a
 printed page. This document describes how to use our page editor.</p>
 
 <p>If you instead want to learn more about our proofing work and how you can
 get started, see our <a href="{{ url_for('proofing.beginners_guide')
-}}">beginner's guide to proofing</a>.</p>
+}}">beginner's guide</a>.</p>
 
 
 <h2>The navigation bar</h2>
@@ -43,7 +35,7 @@ get started, see our <a href="{{ url_for('proofing.beginners_guide')
 can see below:</p>
 </div>
 
-{% call html_figure('The navigation bar for a sample project.') %}
+{% call m_guide.html_figure('The navigation bar for a sample project.') %}
 {{ editor.navigation_bar(
     project={ "title": "madhurAvijayam"|d },
     cur={ "slug": "14", "status": { "name": "reviewed-1" }},
@@ -72,7 +64,7 @@ this page and judged that its transcription was accurate.</p>
 below:</p>
 </div>
 
-{% call html_figure('A menu bar with multiple options available.') %}
+{% call m_guide.html_figure('A menu bar with multiple options available.') %}
 {% set button_css = "block p-2 hover:bg-slate-100 cursor-pointer" %}
 <nav class="border my-2 rounded flex">
   <span class="{{ button_css }}">Layout</span>
@@ -142,7 +134,7 @@ few special Devanagari symbols.</p>
 <p>Next is the <dfn>text editor</dfn>, which you can see below:</p>
 </div>
 
-{% call html_figure('A text editor with multiple options.') %}
+{% call m_guide.html_figure('A text editor with multiple options.') %}
 <div class="border">
   <div class="bg-slate-200 flex justify-between">
     <div>
@@ -180,7 +172,7 @@ let you change the text size, in case you find it hard to read.</p>
 <p>Next we have the <dfn>image viewer</dfn>, which you can see below:</p>
 </div>
 
-{% call html_figure('An image viewer with various options. No image is displayed.') %}
+{% call m_guide.html_figure('An image viewer with various options. No image is displayed.') %}
 <div class="flex flex-col flex-1 border bg-slate-100 border">
   <div class="bg-slate-200">
     {{ editor.alpine_button("&#x1f50d;<sup>+</sup>", "") }}
@@ -220,7 +212,7 @@ comfortably and clearly.</p>
 below:</p>
 </div>
 
-{% call html_figure('The submission form.') %}
+{% call m_guide.html_figure('The submission form.') %}
 <div class="p-4 mt-4 bg-slate-200">
   <label class="text-slate-600 mb-2 block">Summary of changes made</label>
   <input type="text" class="block rounded bg-white w-full mb-4 p-2"></input>

--- a/ambuda/templates/proofing/recent-changes.html
+++ b/ambuda/templates/proofing/recent-changes.html
@@ -9,9 +9,9 @@
 
 
 {% block content %}
-<div class="prose">
-  <h1>Recent changes</h1>
-</div>
+{{ m.title_and_subtitle(
+    "Recent changes",
+    "Recent edits and revisions made by people like you.") }}
 
 {% if revisions %}
 {{ m.revision_list(revisions) }}

--- a/ambuda/templates/proofing/tagging/index.html
+++ b/ambuda/templates/proofing/tagging/index.html
@@ -7,9 +7,11 @@
 
 
 {% block content %}
-<div class="prose">
-<h1>Tagging</h1>
+{{ m.title_and_subtitle(
+    "Tagging",
+    "(coming soon) Tools for tagging and parsing Sanskrit texts.") }}
 
+<div class="prose">
 <p class="p-1 bg-yellow-200">These pages are a work in progress.</p>
 
 <p>We aim to have a full word-by-word analysis for all texts in our library.</p>

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -78,7 +78,7 @@ def beginners_guide():
 @bp.route("/help/complete-guide")
 def complete_guide():
     """Display our complete proofing guidelines."""
-    return render_template("proofing/complete-guidelines.html")
+    return render_template("proofing/complete-guide.html")
 
 
 @bp.route("/help/editor-guide")


### PR DESCRIPTION
- Rename `complete-guidelines` to `complete-guide` for consistency.
- Switch to `title_and_subtitle` headings where feasible.
- Add illustrations to the beginners guide.

Test plan: unit tests and clicked around on dev.