### PR TITLE
Add `make upgrade` script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,27 @@ endif
 install:
 	./scripts/install_from_scratch.sh
 
+# Install frontend dependencies and build CSS and JS assets.
+install-frontend:
+	npm install
+	make css-prod js-prod
+
+# Install Python dependencies.
+install-python:
+	python3 -m venv env
+	bash env/bin/activate
+	pip install --upgrade pip
+	pip install -r requirements.txt
+
+# Upgrade an existing setup.
+upgrade:
+	make install-frontend install-python
+	python -m ambuda.seed.lookup
+	alembic upgrade head
 
 # Seed the database with just enough data for the devserver to be interesting.
 db-seed-basic: py-venv-check
-	python -m ambuda.seed.lookup.role
-	python -m ambuda.seed.lookup.page_status
+	python -m ambuda.seed.lookup
 	python -m ambuda.seed.texts.gretil
 	python -m ambuda.seed.dcs
 	python -m ambuda.seed.dictionaries.monier

--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,14 @@ install-frontend:
 # Install Python dependencies.
 install-python:
 	python3 -m venv env
-	bash env/bin/activate
-	pip install --upgrade pip
-	pip install -r requirements.txt
+	. env/bin/activate; pip install --upgrade pip
+	. env/bin/activate; pip install -r requirements.txt
 
 # Upgrade an existing setup.
 upgrade:
 	make install-frontend install-python
-	python -m ambuda.seed.lookup
-	alembic upgrade head
+	. env/bin/activate; python -m ambuda.seed.lookup
+	. env/bin/activate; alembic upgrade head
 
 # Seed the database with just enough data for the devserver to be interesting.
 db-seed-basic: py-venv-check
@@ -41,7 +40,6 @@ db-seed-basic: py-venv-check
 	python -m ambuda.seed.texts.gretil
 	python -m ambuda.seed.dcs
 	python -m ambuda.seed.dictionaries.monier
-
 
 # Seed the database with all of the text, parse, and dictionary data we serve
 # in production.

--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -103,9 +103,9 @@ def check_app_schema_matches_db_schema(database_uri: str):
     if errors:
         _warn("The data tables defined in your application code don't match the")
         _warn("tables defined in your database. Usually, this means that you need")
-        _warn("to upgrade your database schemas. You can do so by running:")
+        _warn("to upgrade your setup. You can do so by running:")
         _warn()
-        _warn("    alembic upgrade head")
+        _warn("    make upgrade")
         _warn()
         _warn("For more information, see our official docs at:")
         _warn()

--- a/ambuda/seed/lookup/__main__.py
+++ b/ambuda/seed/lookup/__main__.py
@@ -1,0 +1,6 @@
+from ambuda.seed.lookup import page_status
+from ambuda.seed.lookup import role
+
+
+page_status.run()
+role.run()

--- a/fabfile.py
+++ b/fabfile.py
@@ -67,13 +67,8 @@ def deploy_to_commit(_, pointer: str):
 
         # Install project requirements.
         c.run("python3.10 -m venv env")
-        with c.prefix("source env/bin/activate"):
-            c.run("pip install -r requirements.txt")
-
-        # Build production frontend assets.
-        c.run("npm install")
-        c.run("make css-prod")
-        c.run("make js-prod")
+        c.run("make install-python")
+        c.run("make install-frontend")
 
         # Verify that unit tests pass on prod.
         with c.prefix("source env/bin/activate"):

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -29,25 +29,8 @@ fi
 
 echo "Beginning clean install of Ambuda."
 
-
-# Frontend dependencies
-# =====================
-
-# Install Node dependencies.
-npm install
-
-# Build initial CSS and JavaScript.
-make css-prod js-prod
-
-
-# Python dependencies
-# ===================
-
-# Install Python dependencies.
-python3 -m venv env
-source env/bin/activate
-pip install --upgrade pip
-pip install -r requirements.txt
+make install-frontend
+make install-python
 
 # Confirm that the setup worked.
 make test


### PR DESCRIPTION
This command lets contributors sync with the latest production setup.
The command installs our latest Python and Node dependencies and also
upgrades the database by applying migrations and loading any new lookup
tables.

Test plan: ran the command.