### PR TITLE
Make GRETIL seed script more reliable

### DIFF
--- a/ambuda/seed/texts/gretil.py
+++ b/ambuda/seed/texts/gretil.py
@@ -1,18 +1,14 @@
-"""Parse Sanskrit texts from GRETIL.
+"""Upload TEI documents from GRETIL."""
 
-The GRETIL TEI format has some systematic inconsistencies. Instead of using it,
-just process the plain text.
-"""
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from xml.etree import ElementTree as ET
 
-from indic_transliteration import sanscript
 from sqlalchemy.orm import Session
 
 import ambuda.database as db
-from ambuda.seed.utils.itihasa_utils import create_db, delete_existing_text
+from ambuda.seed.utils.itihasa_utils import create_db
+from ambuda.utils.tei_parser import parse_document, Document
 
 
 @dataclass
@@ -26,7 +22,6 @@ REPO = "https://github.com/ambuda-org/gretil.git"
 PROJECT_DIR = Path(__file__).resolve().parents[3]
 DATA_DIR = PROJECT_DIR / "data" / "ambuda-gretil"
 #: Slug to use for texts that have only one section.
-SINGLE_SECTION_SLUG = "all"
 
 ALLOW = [
     Spec("amarushatakam", "amaruzatakam", "sa_amaru-amaruzataka.xml"),
@@ -51,12 +46,8 @@ ALLOW = [
 ]
 
 
-XML_ID_KEY = "{http://www.w3.org/XML/1998/namespace}id"
-NS = {
-    "xml": "http://www.w3.org/XML/1998/namespace",
-    "tei": "http://www.tei-c.org/ns/1.0",
-    "": "http://www.tei-c.org/ns/1.0",
-}
+def log(*a):
+    print(*a)
 
 
 def fetch_latest_data():
@@ -70,161 +61,45 @@ def fetch_latest_data():
     subprocess.call("git reset --hard origin/main", shell=True, cwd=DATA_DIR)
 
 
-@dataclass
-class Block:
-    slug: str
-    #: XML blob.
-    blob: str
+def _create_new_text(session, spec: Spec, document: Document):
+    text = db.Text(slug=spec.slug, title=spec.title, header=document.header)
+    session.add(text)
+    session.flush()
 
-
-@dataclass
-class Section:
-    slug: str
-    blocks: list[Block]
-
-
-@dataclass
-class Document:
-    #: <teiHeader> XML blob.
-    header: str
-    sections: list[Section]
-
-
-def log(*a):
-    print(*a)
-
-
-def remove_namespace(xml: ET.Element, prefix: str):
-    """Remove the given namespace prefix from all elements.
-
-    ElementTree expands tidy namespaced names like "xml:id" into names like
-    "{http://www.w3.org/XML/1998/namespace}id", which are less usable. This
-    function removes these namespaces so that downstream code can be more
-    readable.
-    """
-    for el in xml.iter("*"):
-        if el.tag.startswith(prefix):
-            el.tag = el.tag[len(prefix) :]
-
-
-def to_slp1(xml: ET.Element):
-    """Transliterate inline elements."""
-    t = sanscript.transliterate
-    for el in xml.iter("*"):
-        if el.text:
-            el.text = t(el.text, sanscript.IAST, sanscript.DEVANAGARI)
-        if el.tail:
-            el.tail = t(el.tail, sanscript.IAST, sanscript.DEVANAGARI)
-
-
-def delete_unused_elements(xml: ET.Element):
-    """Remove unused elements in-place."""
-    for L in xml.iter("l"):
-        for el in L:
-            # Delete tag, keep text
-            if el.tag in {"seg", "hi"}:
-                el.tag = None
-            # Delete tag and text.
-            if el.tag in {"note"}:
-                el.tag = None
-                el.clear()
-        text = "".join(L.itertext())
-        text = text.replace("-", "")
-        L.clear()
-        L.text = text
-
-
-def _make_section(xml: ET.Element, section_slug: str) -> Section:
-    section = Section(slug=section_slug, blocks=[])
     n = 1
-    for child in xml:
-        # Skip these elements entirely.
-        if child.tag in {"note", "del"}:
-            continue
+    for section in document.sections:
+        db_section = db.TextSection(
+            text_id=text.id, slug=section.slug, title=section.slug
+        )
+        session.add(db_section)
+        session.flush()
 
-        assert child.tag in {"lg", "head", "p", "trailer", "milestone", "pb"}, child.tag
-        if child.tag == "head":
-            block_slug = "head"
-        else:
-            block_slug = str(n)
+        for block in section.blocks:
+            db_block = db.TextBlock(
+                text_id=text.id,
+                section_id=db_section.id,
+                slug=block.slug,
+                xml=block.blob,
+                n=n,
+            )
+            session.add(db_block)
             n += 1
 
-        blob = ET.tostring(child, encoding="utf-8").decode("utf-8")
-        if section_slug == SINGLE_SECTION_SLUG:
-            slug = block_slug
-        else:
-            slug = f"{section_slug}.{block_slug}"
-        block = Block(slug=slug, blob=blob)
-        section.blocks.append(block)
-
-    return section
-
-
-def parse_sections(xml: ET.Element) -> list[Section]:
-    body = xml.find("./text/body")
-    delete_unused_elements(xml)
-    to_slp1(body)
-
-    sections = []
-    divs = body.findall("./div")
-    if divs:
-        # Text has one or more sections.
-        for i, div in enumerate(body.findall("./div")):
-            section_slug = str(i + 1)
-            section = _make_section(div, section_slug)
-            sections.append(section)
-    else:
-        # Text has exactly one section.
-        section = _make_section(body, SINGLE_SECTION_SLUG)
-        sections = [section]
-    return sections
-
-
-def parse_tei_document(xml: ET.Element) -> Document:
-    remove_namespace(xml, "{" + NS["tei"] + "}")
-
-    header = xml.find("./teiHeader")
-    assert header
-    header_blob = ET.tostring(header, encoding="utf-8").decode("utf-8")
-
-    sections = parse_sections(xml)
-    assert sections
-
-    return Document(header=header_blob, sections=sections)
+    session.commit()
 
 
 def add_document(engine, spec: Spec):
-    log(f"Writing text: {spec.slug}")
     document_path = DATA_DIR / "1_sanskr" / "tei" / spec.filename
 
-    delete_existing_text(engine, spec.slug)
     with Session(engine) as session:
-        xml = ET.parse(document_path).getroot()
-        document = parse_tei_document(xml)
-
-        text = db.Text(slug=spec.slug, title=spec.title, header=document.header)
-        session.add(text)
-        session.flush()
-        n = 1
-        for section in document.sections:
-            db_section = db.TextSection(
-                text_id=text.id, slug=section.slug, title=section.slug
-            )
-            session.add(db_section)
-            session.flush()
-
-            for block in section.blocks:
-                db_block = db.TextBlock(
-                    text_id=text.id,
-                    section_id=db_section.id,
-                    slug=block.slug,
-                    xml=block.blob,
-                    n=n,
-                )
-                session.add(db_block)
-                n += 1
-
-        session.commit()
+        if session.query(db.Text).filter_by(slug=spec.slug).first():
+            # FIXME: update existing texts in-place so that we can capture
+            # changes. As a workaround for now, we can delete then re-create.
+            log(f"- Skipped {spec.slug} (already exists)")
+        else:
+            document = parse_document(document_path)
+            _create_new_text(session, spec, document)
+            log(f"- Created {spec.slug}")
 
 
 def run():

--- a/ambuda/seed/texts/gretil.py
+++ b/ambuda/seed/texts/gretil.py
@@ -1,5 +1,6 @@
 """Upload TEI documents from GRETIL."""
 
+import logging
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -47,7 +48,7 @@ ALLOW = [
 
 
 def log(*a):
-    print(*a)
+    logging.info(*a)
 
 
 def fetch_latest_data():
@@ -103,6 +104,7 @@ def add_document(engine, spec: Spec):
 
 
 def run():
+    logging.getLogger().setLevel(0)
     log("Downloading the latest data ...")
     fetch_latest_data()
 

--- a/ambuda/utils/tei_parser.py
+++ b/ambuda/utils/tei_parser.py
@@ -1,0 +1,188 @@
+"""Utilities for parsing a TEI document.
+
+TEI XML is a rich format for encoding document structure and lineage. We use
+the utilities in this module to convert an XML file into a structured
+representation that we can more easily load into a database.
+
+For a basic introduction to TEI XML, see:
+
+https://ambuda.readthedocs.io/en/latest/tei-xml.html
+
+NOTE: we assume that all documents are in Sanskrit and run transliteration over
+each document with `_to_devanagari`. Once we start supporting translations, we
+should change this logic.
+"""
+
+
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from indic_transliteration import sanscript
+
+
+#: Most texts have multiple sections and use section slugs like "1", "2", etc.
+#: If a text has just one section, we create a single "default" section with
+#: the slug "all".
+SINGLE_SECTION_SLUG = "all"
+#: Tags that we support on our display. If a section contains a tag that's not
+#: in this list, the code below will raise an error.
+SUPPORTED_TAGS = {"lg", "head", "p", "trailer", "milestone", "pb"}
+#: Minimal namespace mapping for TEI documents.
+NS = {
+    "xml": "{http://www.w3.org/XML/1998/namespace}",
+    "tei": "{http://www.tei-c.org/ns/1.0}",
+}
+
+
+@dataclass
+class Block:
+    """A block of content.
+
+    This usually represents an `<lg>` or `<p>` element.
+    """
+
+    #: The URL slug of this block, which we will display in the text URL.
+    slug: str
+    #: XML blob.
+    blob: str
+
+
+@dataclass
+class Section:
+    """A group of blocks.
+
+    This represents a `<div>` element.
+    """
+
+    #: The URL slug of this section, which we will display in the text URL.
+    slug: str
+    #: All blocks that belong to this section, including <head> and <trailer>
+    #: elements.
+    blocks: list[Block]
+
+
+@dataclass
+class Document:
+    """A parsed TEI document.
+
+    This represents a `<TEI>` element with all of its relevant content.
+    """
+
+    #: <teiHeader> XML blob. We use this to display lineage and sourcing
+    #: information on a text's *About* page.
+    header: str
+    #: All sections that belong to this document.
+    sections: list[Section]
+
+
+def _remove_namespace(xml: ET.Element, prefix: str):
+    """Remove the given namespace prefix from all elements.
+
+    ElementTree expands tidy namespaced names like "xml:id" into names like
+    "{http://www.w3.org/XML/1998/namespace}id", which are less usable. This
+    function removes these namespaces so that downstream code can be more
+    readable.
+    """
+    for el in xml.iter("*"):
+        if el.tag.startswith(prefix):
+            el.tag = el.tag[len(prefix) :]
+
+
+def _delete_unused_elements(xml: ET.Element):
+    """Remove unused elements in-place."""
+    for L in xml.iter("l"):
+        for el in L:
+            # Delete tag but keep text.
+            # - `<seg>`: a arbitrary segment, usually representing a pāda.
+            # - `<hi>`: highlighted text, e.g. bold text.
+            if el.tag in {"seg", "hi"}:
+                el.tag = None
+            # Delete tag and text.
+            # - `<note>`: comments by the document editors.
+            if el.tag in {"note"}:
+                el.tag = None
+                el.clear()
+
+        text = "".join(L.itertext())
+        text = text.replace("-", "")
+        L.clear()
+        L.text = text
+
+
+def _to_devanagari(xml: ET.Element):
+    """Transliterate inline elements to Devanagari."""
+    t = sanscript.transliterate
+    for el in xml.iter("*"):
+        if el.text:
+            el.text = t(el.text, sanscript.IAST, sanscript.DEVANAGARI)
+        if el.tail:
+            el.tail = t(el.tail, sanscript.IAST, sanscript.DEVANAGARI)
+
+
+def _create_section(xml: ET.Element, section_slug: str) -> Section:
+    """Create a section with the given slug.
+
+    :param xml: the `Element` corresponding to this section.
+    """
+    section = Section(slug=section_slug, blocks=[])
+    n = 1
+    for child in xml:
+        # Skip these elements entirely.
+        if child.tag in {"note", "del"}:
+            continue
+
+        assert child.tag in SUPPORTED_TAGS, child.tag
+        if child.tag == "head":
+            block_slug = "head"
+        else:
+            block_slug = str(n)
+            n += 1
+
+        blob = ET.tostring(child, encoding="utf-8").decode("utf-8")
+        if section_slug == SINGLE_SECTION_SLUG:
+            full_slug = block_slug
+        else:
+            full_slug = f"{section_slug}.{block_slug}"
+        block = Block(slug=full_slug, blob=blob)
+        section.blocks.append(block)
+
+    all_slugs = [x.slug for x in section.blocks]
+    if len(set(all_slugs)) != len(section.blocks):
+        slug_list = ", ".join(sorted(all_slugs))
+        raise ValueError(f"Block slugs are not unique: {slug_list}")
+    return section
+
+
+def _parse_sections(xml: ET.Element) -> list[Section]:
+    body = xml.find("./text/body")
+    _delete_unused_elements(xml)
+    _to_devanagari(body)
+
+    sections = []
+    divs = body.findall("./div")
+    if divs:
+        # Text has one or more sections.
+        for i, div in enumerate(body.findall("./div")):
+            section_slug = str(i + 1)
+            section = _create_section(div, section_slug)
+            sections.append(section)
+    else:
+        # Text has exactly one section.
+        section = _create_section(body, SINGLE_SECTION_SLUG)
+        sections = [section]
+    return sections
+
+
+def parse_document(path: Path) -> Document:
+    xml = ET.parse(path).getroot()
+    _remove_namespace(xml, NS["tei"])
+
+    header = xml.find("./teiHeader")
+    assert header
+    header_blob = ET.tostring(header, encoding="utf-8").decode("utf-8")
+
+    sections = _parse_sections(xml)
+    assert sections
+
+    return Document(header=header_blob, sections=sections)

--- a/test/ambuda/utils/test_tei_parser.py
+++ b/test/ambuda/utils/test_tei_parser.py
@@ -1,0 +1,51 @@
+import xml.etree.ElementTree as ET
+
+import ambuda.utils.tei_parser as tei
+
+
+def test_delete_unused_elements():
+    blob = "".join(
+        [
+            "<lg>"
+            "<l><seg>segment</seg> <hi>hi</hi></l>"
+            "<l>text<note>note</note></l>"
+            "</lg>"
+        ]
+    )
+    xml = ET.fromstring(blob)
+    tei._delete_unused_elements(xml)
+
+    actual = ET.tostring(xml, encoding="utf-8").decode("utf-8")
+    assert actual == "<lg><l>segment hi</l><l>text</l></lg>"
+
+
+def test_to_devanagari():
+    xml = ET.fromstring("<div><span>a</span>ka</div>")
+    tei._to_devanagari(xml)
+
+    actual = ET.tostring(xml, encoding="utf-8").decode("utf-8")
+    assert actual == "<div><span>अ</span>क</div>"
+
+
+def test_create_section():
+    blob = "".join(
+        [
+            "<div>",
+            "<lg xml:id='Test.1'>a</lg>",
+            "<lg xml:id='Test.2'>b</lg>",
+            "<lg xml:id='Test.3'>c</lg>",
+            "</div>",
+        ]
+    )
+    xml = ET.fromstring(blob)
+    tei._remove_namespace(xml, "{" + tei.NS["tei"] + "}")
+    section = tei._create_section(xml, "s1")
+
+    assert section.slug == "s1"
+    assert len(section.blocks) == 3
+    assert [x.slug for x in section.blocks] == ["s1.1", "s1.2", "s1.3"]
+    assert [x.blob for x in section.blocks] == [
+        '<lg xml:id="Test.1">a</lg>',
+        '<lg xml:id="Test.2">b</lg>',
+        '<lg xml:id="Test.3">c</lg>',
+    ]


### PR DESCRIPTION
Major changes:
- The script is now idempotent. That is, running it over and over will
  have the same impact on the database.
- The script won't delete existing texts. This prevents a previous rough
  edge where running the seed script would delete all parse data in
  prod.
- TEI parsing functions are now in `tei_parsing.py`, where we can reuse
  them for future applications (other TEI upload scripts, uploading
  through the website, etc.)
- The script has some basic unit tests.

Test plan: ran the script.