### PR TITLE
Add placeholder text for empty queries 

### DIFF
--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -1,6 +1,7 @@
 {% import 'macros/components.html' as components %}
 
 
+{# Display a title+subtitle pair. #}
 {% macro title_and_subtitle(title, subtitle = none) %}
 <header class="mb-4">
   <h1 class="font-bold text-4xl">{{ title|safe }}</h1>

--- a/ambuda/templates/proofing/index.html
+++ b/ambuda/templates/proofing/index.html
@@ -28,6 +28,8 @@
 <div class="prose">
 <h1 class="md:!mt-0">Ongoing projects</h1>
 </div>
+
+{% if projects %}
 {{ status_legend() }}
 
 <div x-data="sortableList('title')">
@@ -70,4 +72,11 @@
   {% endfor %}
 </ul>
 </div>
+{% else %}
+<div class="prose">
+<p>There aren't any ongoing projects. <a href="{{ url_for('proofing.create_project') }}">
+    Create a new project to get started</a>.</p>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/ambuda/templates/proofing/talk.html
+++ b/ambuda/templates/proofing/talk.html
@@ -27,6 +27,9 @@
     </div>
     <p class="text-sm">{{ thread.updated_at|time_ago }}</p>
   </li>
+{% else %}
+<p>There isn't any ongoing discussion yet. To start a discussion, go to the
+project you want to discuss and click on its <kbd>Talk</kbd> tab.</p>
 {% endfor %}
 
 {% endblock %}

--- a/ambuda/templates/proofing/user/summary.html
+++ b/ambuda/templates/proofing/user/summary.html
@@ -10,16 +10,21 @@
 
 
 {% block content %}
-{{ components.flash_messages() }}
-
 {{ m.title_and_subtitle(user.username) }}
 
 {{ m.user_tabs(user=user, active='about', is_admin=current_user.is_admin) }}
 
 {% if user.description %}
-
 <div class="prose border p-4 my-8">
 {{ user.description|markdown|safe }}
+</div>
+{% else %}
+<div class="prose">
+  {% if current_user.id == user.id %}
+  <p>Tell others who you are by writing a short bio!</p>
+  {% else %}
+  <p>This user hasn't written anything about themselves.</p>
+  {% endif %}
 </div>
 {% endif %}
 

--- a/test/ambuda/views/proofing/test_user.py
+++ b/test/ambuda/views/proofing/test_user.py
@@ -11,7 +11,7 @@ def test_edit__user_match(rama_client):
 def test_edit__user_match__post(rama_client):
     resp = rama_client.get("/proofing/users/ramacandra/")
     assert resp.status_code == 200
-    assert "This user hasn't" in resp.text
+    assert "Tell others who you are" in resp.text
 
     resp = rama_client.post(
         "/proofing/users/ramacandra/edit", data={"description": "My description"}

--- a/test/ambuda/views/proofing/test_user.py
+++ b/test/ambuda/views/proofing/test_user.py
@@ -11,7 +11,7 @@ def test_edit__user_match(rama_client):
 def test_edit__user_match__post(rama_client):
     resp = rama_client.get("/proofing/users/ramacandra/")
     assert resp.status_code == 200
-    assert "My description" not in resp.text
+    assert "This user hasn't" in resp.text
 
     resp = rama_client.post(
         "/proofing/users/ramacandra/edit", data={"description": "My description"}


### PR DESCRIPTION
Examples:
- A user doesn't have a description.
- The proofing interface doesn't have any texts.
- There's no ongoing discussion.