### PR TITLE
Optimize proofing.index query

### DIFF
--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -11,6 +11,7 @@ from flask import (
 from flask_login import current_user, login_required
 from flask_wtf import FlaskForm
 from slugify import slugify
+from sqlalchemy import orm
 from wtforms import StringField, FileField
 from wtforms.validators import DataRequired
 
@@ -37,7 +38,19 @@ class CreateProjectWithPdfForm(FlaskForm):
 @bp.route("/")
 def index():
     """List all available proofing projects."""
-    projects = q.projects()
+
+    session = q.get_session()
+
+    # Fetch all project data in a single query for better performance.
+    projects = (
+        session.query(db.Project)
+        .options(
+            orm.joinedload(db.Project.pages)
+            .load_only(db.Page.id)
+            .joinedload(db.Page.status)
+        )
+        .all()
+    )
 
     all_counts = {}
     all_page_counts = {}

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -39,9 +39,8 @@ class CreateProjectWithPdfForm(FlaskForm):
 def index():
     """List all available proofing projects."""
 
-    session = q.get_session()
-
     # Fetch all project data in a single query for better performance.
+    session = q.get_session()
     projects = (
         session.query(db.Project)
         .options(


### PR DESCRIPTION
The page is loading slowly for me in prod. Upon debugging, I found that
our current prod setup runs N+2 queries, where N is the number of
projects:

- 1 to fetch all projects
- N to fetch pages for each project
- 1 to fetch page statuses

Since we use sqlite, this isn't as bad as it seems. But even so, I
thought there was room to improve this query by fetching our data in one
trip and dropping extraneous fields.

Test plan: unit tests and ran the query on dev.