### PR TITLE
Add sorting options for project list

### DIFF
--- a/ambuda/enums.py
+++ b/ambuda/enums.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class SiteRole(Enum):
+class SiteRole(str, Enum):
     """Defines user roles on Ambuda."""
 
     #: Can mark pages as yellow
@@ -10,3 +10,16 @@ class SiteRole(Enum):
     P2 = "p2"
     #: Administrator rights
     ADMIN = "admin"
+
+
+class SitePageStatus(str, Enum):
+    """Defines page statuses."""
+
+    #: Needs more work
+    R0 = "reviewed-0"
+    #: Proofread once.
+    R1 = "reviewed-1"
+    #: Proofread twice.
+    R2 = "reviewed-2"
+    #: Not relevant.
+    SKIP = "skip"

--- a/ambuda/seed/lookup/page_status.py
+++ b/ambuda/seed/lookup/page_status.py
@@ -1,39 +1,27 @@
 from sqlalchemy.orm import Session
 
 import ambuda.database as db
+from ambuda.enums import SitePageStatus
 from ambuda.seed.utils.itihasa_utils import create_db
 
 import logging
-
-
-FIELD_NAMES = [
-    # Page has never been fully proofread.
-    "reviewed-0",
-    # Page has been fully proofread once.
-    "reviewed-1",
-    # Page has been fully proofread twice.
-    "reviewed-2",
-    # Page is out of scope for proofreading.
-    "skip",
-]
 
 
 def get_default_id():
     """Used in the `add_page_statuses` migration."""
     engine = create_db()
     with Session(engine) as session:
-        return session.query(db.PageStatus).filter_by(name="reviewed-0").one()
+        return session.query(db.PageStatus).filter_by(name=SitePageStatus.R0).one()
 
 
 def run():
     """Create page statuses iff they don't exist already."""
-
     engine = create_db()
     logging.debug("Creating PageStatus rows ...")
     with Session(engine) as session:
         statuses = session.query(db.PageStatus).all()
         existing_names = {s.name for s in statuses}
-        new_names = {n for n in FIELD_NAMES if n not in existing_names}
+        new_names = {n.value for n in SitePageStatus if n not in existing_names}
 
         if new_names:
             for name in new_names:

--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -2,22 +2,18 @@
 
 import { $ } from './core.ts';
 import Dictionary from './dictionary';
+import HamburgerButton from './hamburger-button';
 import Reader from './reader';
 import Proofer from './proofer';
-import HamburgerButton from './hamburger-button';
+import SortableList from './sortable-list';
 
 window.addEventListener('alpine:init', () => {
   Alpine.data('dictionary', Dictionary);
   Alpine.data('reader', Reader);
   Alpine.data('proofer', Proofer);
+  Alpine.data('sortableList', SortableList);
 });
 
 (() => {
   HamburgerButton.init();
 })();
-
-// Export a few internal values to support some existing ad-hoc usage (e.g.,
-// in the pages that shows the progress bar for a project upload.)
-// FIXME(arun): clean up existing usage of these values so that our code is less
-// FIXME(arun): ad-hoc.
-window.$ = $;

--- a/ambuda/static/js/sortable-list.js
+++ b/ambuda/static/js/sortable-list.js
@@ -1,0 +1,22 @@
+function sortAscending(field) {
+  return (a, b) => (a.dataset[field] < b.dataset[field] ? -1 : 1);
+}
+
+function sortDescending(field) {
+  return (a, b) => (a.dataset[field] < b.dataset[field] ? 1 : -1);
+}
+
+export default (defaultField) => ({
+  // The sort field. Initialize this in `x-init`.
+  field: defaultField,
+  // The order ("asc" or "desc"). Initialize this in `x-init`.
+  order: 'asc',
+
+  sort() {
+    const orderFn = this.order === 'asc' ? sortAscending : sortDescending;
+    const { list } = this.$refs;
+    [...list.children]
+      .sort(orderFn(this.field))
+      .forEach((node) => list.appendChild(node));
+  },
+});

--- a/ambuda/templates/proofing/index.html
+++ b/ambuda/templates/proofing/index.html
@@ -30,12 +30,13 @@
 </div>
 {{ status_legend() }}
 
-<div x-data="sortableList('created')">
+<div x-data="sortableList('title')">
 
 <form class="border p-2 rounded text-sm">
 <label class="text-slate-500">Sort by:</label>
 <select class="bg-white" x-model="field" @change="sort">
-  <option value="created" selected>Creation date</option> 
+  <option value="title" selected>Title</option> 
+  <option value="created">Creation date</option> 
   <option value="progress">Progress</option> 
 </select>
 <select class="bg-white" x-model="order" @change="sort">
@@ -46,7 +47,9 @@
 
 <ul x-ref="list">
   {% for p in projects %}
-  <li data-created="{{ p.created_at }}" data-progress="{{ progress_per_project[p.id] }}">
+  <li data-title="{{ p.title }}"
+      data-created="{{ p.created_at }}"
+      data-progress="{{ progress_per_project[p.id] }}">
     <div class="mt-4 a-hover-underline flex justify-between items-baseline">
       <a href="{{ url_for("proofing.project.summary", slug=p.slug) }}">{{ p.title }}</a>
       <span class="text-xs">{{ pages_per_project[p.id] }} pages</span>

--- a/ambuda/templates/proofing/index.html
+++ b/ambuda/templates/proofing/index.html
@@ -30,17 +30,31 @@
 </div>
 {{ status_legend() }}
 
-<ul>
+<div x-data="sortableList('created')">
+
+<form class="border p-2 rounded text-sm">
+<label class="text-slate-500">Sort by:</label>
+<select class="bg-white" x-model="field" @change="sort">
+  <option value="created" selected>Creation date</option> 
+  <option value="progress">Progress</option> 
+</select>
+<select class="bg-white" x-model="order" @change="sort">
+  <option value="asc" selected>Ascending</option> 
+  <option value="desc">Descending</option> 
+</select>
+</form>
+
+<ul x-ref="list">
   {% for p in projects %}
-  <li>
+  <li data-created="{{ p.created_at }}" data-progress="{{ progress_per_project[p.id] }}">
     <div class="mt-4 a-hover-underline flex justify-between items-baseline">
       <a href="{{ url_for("proofing.project.summary", slug=p.slug) }}">{{ p.title }}</a>
-      <span class="text-xs">({{ all_page_counts[p.slug] }} pages)</span>
+      <span class="text-xs">{{ pages_per_project[p.id] }} pages</span>
     </div>
 
     <div class="flex">
-    {% for cls, width in all_counts[p.slug].items() %}
-      <div class="h-1 {{ cls }}" style="width: {{ width * 100 }}%"></div>
+    {% for cls, fraction in statuses_per_project[p.id].items() %}
+      <div class="h-1 {{ cls }}" style="width: {{ fraction * 100 }}%"></div>
     {% endfor %}
     </div>
 
@@ -52,4 +66,5 @@
   </li>
   {% endfor %}
 </ul>
+</div>
 {% endblock %}

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -17,6 +17,7 @@ from wtforms.validators import DataRequired
 
 import ambuda.queries as q
 from ambuda import database as db
+from ambuda.enums import SitePageStatus
 from ambuda.tasks import projects as project_tasks
 
 
@@ -38,6 +39,7 @@ class CreateProjectWithPdfForm(FlaskForm):
 @bp.route("/")
 def index():
     """List all available proofing projects."""
+<<<<<<< HEAD
 
     # Fetch all project data in a single query for better performance.
     session = q.get_session()
@@ -50,34 +52,44 @@ def index():
         )
         .all()
     )
+    status_classes = {
+        SitePageStatus.R2: "bg-green-200",
+        SitePageStatus.R1: "bg-yellow-200",
+        SitePageStatus.R0: "bg-red-300",
+        SitePageStatus.SKIP: "bg-slate-100",
+    }
 
-    all_counts = {}
-    all_page_counts = {}
+    projects = q.projects()
+    statuses_per_project = {}
+    progress_per_project = {}
+    pages_per_project = {}
     for project in projects:
         page_statuses = [p.status.name for p in project.pages]
 
         # FIXME(arun): catch this properly, prevent prod issues
         if not page_statuses:
-            all_counts[project.slug] = {}
-            all_page_counts[project.slug] = 0
+            statuses_per_project[project.id] = {}
+            pages_per_project[project.id] = 0
             continue
 
         num_pages = len(page_statuses)
-        project_counts = {
-            "bg-green-200": page_statuses.count("reviewed-2") / num_pages,
-            "bg-yellow-200": page_statuses.count("reviewed-1") / num_pages,
-            "bg-red-300": page_statuses.count("reviewed-0") / num_pages,
-            "bg-slate-100": page_statuses.count("skip") / num_pages,
-        }
+        project_counts = {}
+        for enum_value, class_ in status_classes.items():
+            fraction = page_statuses.count(enum_value) / num_pages
+            project_counts[class_] = fraction
+            if enum_value == SitePageStatus.R0:
+                # The more red pages there are, the lower progress is.
+                progress_per_project[project.id] = 1 - fraction
 
-        all_counts[project.slug] = project_counts
-        all_page_counts[project.slug] = num_pages
+        statuses_per_project[project.id] = project_counts
+        pages_per_project[project.id] = num_pages
 
     return render_template(
         "proofing/index.html",
         projects=projects,
-        all_counts=all_counts,
-        all_page_counts=all_page_counts,
+        statuses_per_project=statuses_per_project,
+        progress_per_project=progress_per_project,
+        pages_per_project=pages_per_project,
     )
 
 

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -39,7 +39,6 @@ class CreateProjectWithPdfForm(FlaskForm):
 @bp.route("/")
 def index():
     """List all available proofing projects."""
-<<<<<<< HEAD
 
     # Fetch all project data in a single query for better performance.
     session = q.get_session()
@@ -84,6 +83,7 @@ def index():
         statuses_per_project[project.id] = project_counts
         pages_per_project[project.id] = num_pages
 
+    projects.sort(key=lambda x: x.title)
     return render_template(
         "proofing/index.html",
         projects=projects,

--- a/test/js/sortable-list.test.js
+++ b/test/js/sortable-list.test.js
@@ -1,0 +1,52 @@
+import { $ } from '@/core.ts';
+import SortableList from '@/sortable-list';
+
+const sampleHTML = `
+<ul>
+  <li data-foo="a" data-bar="3">A</li>
+  <li data-foo="b" data-bar="1">B</li>
+  <li data-foo="c" data-bar="2">C</li>
+</ul>
+`;
+
+beforeEach(() => {
+  document.write(sampleHTML);
+});
+
+function getText(list) {
+  return [...list.children].map(x => x.textContent);
+}
+
+test('SortableList can be created', () => {
+  const s = SortableList('foo');
+  s.$refs = { list: document.querySelector('ul') };
+  expect(s.field).toBe('foo');
+  expect(s.order).toBe('asc');
+
+  const results = getText(s.$refs.list);
+  expect(results).toEqual(['A', 'B', 'C']);
+});
+
+test('sort ascending', () => {
+  const s = SortableList('foo');
+  s.$refs = { list: document.querySelector('ul') };
+
+  s.field = 'bar';
+  s.sort();
+
+  const results = getText(s.$refs.list);
+  expect(results).toEqual(['B', 'C', 'A']);
+});
+
+
+test('sort descending', () => {
+  const s = SortableList('foo');
+  s.$refs = { list: document.querySelector('ul') };
+
+  s.field = 'bar';
+  s.order = 'desc'
+  s.sort();
+
+  const results = getText(s.$refs.list);
+  expect(results).toEqual(['A', 'C', 'B']);
+});


### PR DESCRIPTION
The UX isn't great, but this lets us sort a list of projects by:
- creation date
- total progress, measured as the number of red pages left.

Test plan: unit tests and tried the component on dev.

<img width="516" alt="image" src="https://user-images.githubusercontent.com/1429776/187536937-abbecae8-1338-418f-a981-9c7efe06f8c6.png">
