### PR TITLE
Add moderator role

### DIFF
--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -82,10 +82,6 @@ def create_app(config_env: str):
     load_dotenv(".env")
     config_spec = config.load_config_object(config_env)
 
-    # Sanity checks
-    if config_env != config.TESTING:
-        checks.check_app_schema_matches_db_schema(config_spec.SQLALCHEMY_DATABASE_URI)
-
     # Initialize Sentry monitoring only in production so that our Sentry page
     # contains only production warnings (as opposed to dev warnings).
     #
@@ -98,6 +94,11 @@ def create_app(config_env: str):
 
     # Config
     app.config.from_object(config_spec)
+
+    # Sanity checks
+    if config_env != config.TESTING:
+        with app.app_context():
+            checks.check_database(config_spec.SQLALCHEMY_DATABASE_URI)
 
     # Logger
     _initialize_logger(config_spec.LOG_LEVEL)

--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -9,6 +9,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.schema import Column
 from sqlalchemy import inspect
 
+from ambuda import database as db
+from ambuda import enums
+from ambuda import queries as q
 from ambuda.models.base import Base
 
 
@@ -42,7 +45,7 @@ def _check_column(app_col: Column, db_col: dict[str, str]) -> list[str]:
     return errors
 
 
-def check_app_schema_matches_db_schema(database_uri: str):
+def _check_app_schema_matches_db_schema(database_uri: str) -> list[str]:
     """Check that our application tables and database tables match.
 
     Currently, we apply the following checks:
@@ -100,6 +103,42 @@ def check_app_schema_matches_db_schema(database_uri: str):
             if column_errors:
                 errors.extend(column_errors)
 
+    return errors
+
+
+def _check_lookup_tables(database_uri: str) -> list[str]:
+    engine = create_engine(database_uri)
+    session = q.get_session()
+    lookups = [
+        (enums.SitePageStatus, db.PageStatus),
+        (enums.SiteRole, db.Role),
+    ]
+
+    errors = []
+    for enum, model in lookups:
+        items = session.query(model).all()
+        db_names = {x.name for x in items}
+        app_names = {x.value for x in enum}
+
+        enum_name = enum.__name__
+        table_name = model.__tablename__
+        for field_name in db_names - app_names:
+            errors.append(
+                f'Enum field "{enum_name}.{field_name}" not defined on database table "{table_name}".'
+            )
+
+        for field_name in app_names - db_names:
+            errors.append(
+                f'Table row ({table_name} where name = "{field_name}") not defined on enum "{enum_name}".'
+            )
+
+    return errors
+
+
+def check_database(database_uri: str):
+    errors = _check_app_schema_matches_db_schema(database_uri)
+    errors += _check_lookup_tables(database_uri)
+
     if errors:
         _warn("The data tables defined in your application code don't match the")
         _warn("tables defined in your database. Usually, this means that you need")
@@ -113,8 +152,6 @@ def check_app_schema_matches_db_schema(database_uri: str):
         _warn()
         _warn("If the error persists, please ping the #backend channel on the")
         _warn("Ambuda Discord server (https://discord.gg/7rGdTyWY7Z).")
-        _warn()
-        _warn("Errors found:")
         _warn()
         for error in errors:
             _warn(f"- {error}")

--- a/ambuda/enums.py
+++ b/ambuda/enums.py
@@ -4,11 +4,15 @@ from enum import Enum
 class SiteRole(str, Enum):
     """Defines user roles on Ambuda."""
 
-    #: Can mark pages as yellow
+    #: Basic proofer. Can mark pages as yellow and upload simple projects.
     P1 = "p1"
-    #: Can mark pages as green
+    #: Advanced proofer. Can mark pages as green, upload arbitrary PDFs, and
+    #: run operations across an entire project.
     P2 = "p2"
-    #: Administrator rights
+    #: Moderator. Can delete projects, ban users, and run operations across the
+    #: entire proofing effort.
+    MODERATOR = "moderator"
+    #: Administrator. Has full access to the database.
     ADMIN = "admin"
 
 

--- a/ambuda/enums.py
+++ b/ambuda/enums.py
@@ -9,8 +9,8 @@ class SiteRole(str, Enum):
     #: Advanced proofer. Can mark pages as green, upload arbitrary PDFs, and
     #: run operations across an entire project.
     P2 = "p2"
-    #: Moderator. Can delete projects, ban users, and run operations across the
-    #: entire proofing effort.
+    #: Moderator. Can delete projects, promote and ban users, and run
+    #: operations across the entire proofing effort.
     MODERATOR = "moderator"
     #: Administrator. Has full access to the database.
     ADMIN = "admin"


### PR DESCRIPTION
The moderator role is between an admin and a p2 proofer. Moderators will
be able to delete projects, ban users, promote users, and otherwise run
operations across the entire proofing effort.

This commit just defines the role without any additional functionality.
Future commits will grant the moderator express rights.

Fixes #298.