### PR TITLE
Show created projects in logs

### DIFF
--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -55,6 +55,7 @@
 {% macro project_nav(project, active, is_admin = false) %}
 {% set routes = [
   ("summary",  "Summary",  url_for("proofing.project.summary", slug=project.slug)),
+  ("activity", "Activity",  url_for("proofing.project.activity", slug=project.slug)),
   ("talk",     "Talk",     url_for("proofing.talk.board", slug=project.slug)),
   ("edit",     "Edit",     url_for("proofing.project.edit", slug=project.slug)),
   ("download", "Download", url_for("proofing.project.download", slug=project.slug)),
@@ -115,28 +116,59 @@
 {% endmacro %}
 
 
+{# A revision in an activity log. #}
+{% macro revision_li(r) %}
+<li class="my-2">
+  {% set revision_url = url_for('proofing.page.revision',
+      project_slug=r.project.slug, page_slug=r.page.slug, revision_id=r.id) %}
+  {% set page_url = url_for('proofing.page.edit',
+      project_slug=r.project.slug, page_slug=r.page.slug) %}
+  {% set author_url = url_for('proofing.user.summary',
+      username=r.author.username) %}
+  {% set page_title = r.project.title + "/" + r.page.slug %}
+  {% set author = r.author.username %}
+
+  <span class="{{ revision_colors(r.status.name) }} inline-block w-2 h-2 mr-0.5 rounded-sm"></span>
+  <a class="text-slate-400 text-sm p-0.5 rounded"
+      href="{{ revision_url }}">{{ r.created.strftime("%Y-%m-%d %H:%M") }}</a>
+  <a href="{{ page_url }}">{{ page_title }}</a>
+  by <a href="{{ author_url }}">{{ author }}</a>
+  {% if r.summary %}<i>({{ r.summary }})</i>{% endif %}
+</li>
+{% endmacro %}
+
+
+{# A project in an activity log #} 
+{% macro project_li(p) %}
+<li class="my-2 flex justify-between">
+  {% set project_url = url_for('proofing.project.summary', slug=p.slug) %}
+  {% set creator = p.creator.username %}
+  {% set creator_url = url_for('proofing.user.summary', username=creator) %}
+  <div>
+    <span class="border border-slate-500 inline-block w-2 h-2 mr-0.5 rounded-sm"></span>
+    <a class="text-slate-400 text-sm p-0.5 rounded"
+        href="{{ project_url }}">{{ p.created_at.strftime("%Y-%m-%d %H:%M") }}</a>
+    {{ p.title }} created by <a href="{{ creator_url }}">{{ creator }}</a>
+</li>
+{% endmacro %}
+
+
+{# List various activity (edits, new projects, etc.) #}
+{% macro activity_log(activity) %}
+<ul class="a-hover-underline">
+{% for type_, _, obj in activity %}
+  {% if type_ == 'revision' %}{{ revision_li(obj) }}
+  {% elif type_ == 'project' %}{{ project_li(obj) }}
+  {% endif %}
+{% endfor %}
+</ul>
+{% endmacro %}
+
+
 {# List the given revisions. Revisions might correspond to multiple pages. #}
 {% macro revision_list(revisions) %}
 <ul class="a-hover-underline">
-  {% for r in revisions %}
-  <li class="my-2">
-    {% set revision_url = url_for('proofing.page.revision',
-        project_slug=r.project.slug, page_slug=r.page.slug, revision_id=r.id) %}
-    {% set page_url = url_for('proofing.page.edit',
-        project_slug=r.project.slug, page_slug=r.page.slug) %}
-    {% set author_url = url_for('proofing.user.summary',
-        username=r.author.username) %}
-    {% set page_title = r.project.title + "/" + r.page.slug %}
-    {% set author = r.author.username %}
-
-    <span class="{{ revision_colors(r.status.name) }} inline-block w-2 h-2 mr-0.5 rounded-full"></span>
-    <a class="text-slate-400 text-sm p-0.5 rounded"
-        href="{{ revision_url }}">{{ r.created.strftime("%Y-%m-%d %H:%M") }}</a>
-    <a href="{{ page_url }}">{{ page_title }}</a>
-    by <a href="{{ author_url }}">{{ author }}</a>
-    {% if r.summary %}<i>({{ r.summary }})</i>{% endif %}
-  </li>
-  {% endfor %}
+  {% for r in revisions %}{{ revision_li(r) }}{% endfor %}
 </ul>
 {% endmacro %}
 

--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -138,7 +138,7 @@
 {% endmacro %}
 
 
-{# A project in an activity log #} 
+{# A project in an activity log #}
 {% macro project_li(p) %}
 <li class="my-2 flex justify-between">
   {% set project_url = url_for('proofing.project.summary', slug=p.slug) %}

--- a/ambuda/templates/proofing/projects/activity.html
+++ b/ambuda/templates/proofing/projects/activity.html
@@ -1,0 +1,20 @@
+{% extends 'proofing/base-sidebar.html' %}
+{% import "macros/components.html" as components %}
+{% import "macros/forms.html" as mf %}
+{% import "macros/proofing.html" as m %}
+
+
+{% block title %}Activity: {{ project.title }} | Ambuda{% endblock %}
+
+
+{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+
+
+{% block content %}
+{{ m.project_header_nested('Activity', project) }}
+{{ m.project_nav(project=project, active='activity', is_admin=current_user.is_admin) }}
+{% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
+
+{{ m.activity_log(recent_activity) }}
+
+{% endblock %}

--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -4,15 +4,15 @@
 {% import "macros/proofing.html" as m %}
 
 
-{% block title %}Activity: {{ project.title }} | Ambuda{% endblock %}
+{% block title %}Edit: {{ project.title }} | Ambuda{% endblock %}
 
 
 {% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
 
 
 {% block content %}
-{{ m.project_header_nested('Activity', project) }}
-{{ m.project_nav(project=project, active='activity', is_admin=current_user.is_admin) }}
+{{ m.project_header_nested('Edit', project) }}
+{{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
 
 <div class="prose">

--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -4,15 +4,15 @@
 {% import "macros/proofing.html" as m %}
 
 
-{% block title %}Edit: {{ project.title }} | Ambuda{% endblock %}
+{% block title %}Activity: {{ project.title }} | Ambuda{% endblock %}
 
 
 {% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
 
 
 {% block content %}
-{{ m.project_header_nested('Edit', project) }}
-{{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
+{{ m.project_header_nested('Activity', project) }}
+{{ m.project_nav(project=project, active='activity', is_admin=current_user.is_admin) }}
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
 
 <div class="prose">

--- a/ambuda/templates/proofing/recent-changes.html
+++ b/ambuda/templates/proofing/recent-changes.html
@@ -11,10 +11,10 @@
 {% block content %}
 {{ m.title_and_subtitle(
     "Recent changes",
-    "Recent edits and revisions made by people like you.") }}
+    "Recent edits and revisions made by people like you!") }}
 
-{% if revisions %}
-{{ m.revision_list(revisions) }}
+{% if recent_activity -%}
+{{ m.activity_log(recent_activity) }}
 {% else %}
 <p>No changes found.</p>
 {% endif %}

--- a/ambuda/templates/proofing/user/activity.html
+++ b/ambuda/templates/proofing/user/activity.html
@@ -30,10 +30,12 @@
 <div class="prose">
 <h2>Edits</h2>
 </div>
-{{ m.revision_list(user_revisions|reverse) }}
+
+{% if user_revisions %}
+{{ m.revision_list(user_revisions) }}
 {% else %}
 <p>This user has not made any edits.</p>
 {% endif %}
 
+{% endif %}
 {% endblock %}
-

--- a/ambuda/templates/proofing/user/activity.html
+++ b/ambuda/templates/proofing/user/activity.html
@@ -18,7 +18,7 @@
 
 {{ m.user_tabs(user=user, active='activity', is_admin=current_user.is_admin) }}
 
-{% if user_revisions %}
+{% if recent_activity %}
 <div class="prose">
 <h2>Summary</h2>
 </div>
@@ -28,14 +28,12 @@
 </div>
 
 <div class="prose">
-<h2>Edits</h2>
+<h2>All changes</h2>
 </div>
 
-{% if user_revisions %}
-{{ m.revision_list(user_revisions) }}
-{% else %}
-<p>This user has not made any edits.</p>
-{% endif %}
+{{ m.activity_log(recent_activity) }}
 
+{% else %}
+<p>This user has not made any changes.</p>
 {% endif %}
 {% endblock %}

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -182,12 +182,19 @@ def recent_changes():
     """Show recent changes across all projects."""
     session = q.get_session()
     recent_revisions = (
-        session.query(db.Revision).order_by(db.Revision.created.desc()).limit(100).all()
+        session.query(db.Revision)
+        .options(orm.defer(db.Revision.content))
+        .order_by(db.Revision.created.desc())
+        .limit(100)
+        .all()
     )
     recent_activity = [("revision", r.created, r) for r in recent_revisions]
 
     recent_projects = (
-        session.query(db.Project).order_by(db.Project.created_at.desc()).all()
+        session.query(db.Project)
+        .order_by(db.Project.created_at.desc())
+        .limit(100)
+        .all()
     )
     recent_activity += [("project", p.created_at, p) for p in recent_projects]
 

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -184,7 +184,17 @@ def recent_changes():
     recent_revisions = (
         session.query(db.Revision).order_by(db.Revision.created.desc()).limit(100).all()
     )
-    return render_template("proofing/recent-changes.html", revisions=recent_revisions)
+    recent_activity = [("revision", r.created, r) for r in recent_revisions]
+
+    recent_projects = (
+        session.query(db.Project).order_by(db.Project.created_at.desc()).all()
+    )
+    recent_activity += [("project", p.created_at, p) for p in recent_projects]
+
+    recent_activity.sort(key=lambda x: x[1], reverse=True)
+    return render_template(
+        "proofing/recent-changes.html", recent_activity=recent_activity
+    )
 
 
 @bp.route("/talk")

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -104,6 +104,31 @@ def summary(slug):
     )
 
 
+@bp.route("/<slug>/activity")
+def activity(slug):
+    """Download the project in various output formats."""
+    project_ = q.project(slug)
+    if project_ is None:
+        abort(404)
+
+    session = q.get_session()
+    recent_revisions = (
+        session.query(db.Revision)
+        .filter_by(project_id=project_.id)
+        .order_by(db.Revision.created.desc())
+        .limit(100)
+        .all()
+    )
+    recent_activity = [("revision", r.created, r) for r in recent_revisions]
+    recent_activity.append(("project", project_.created_at, project_))
+
+    return render_template(
+        "proofing/projects/activity.html",
+        project=project_,
+        recent_activity=recent_activity,
+    )
+
+
 @bp.route("/<slug>/edit", methods=["GET", "POST"])
 @login_required
 def edit(slug):

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -106,7 +106,7 @@ def summary(slug):
 
 @bp.route("/<slug>/activity")
 def activity(slug):
-    """Download the project in various output formats."""
+    """Show recent activity on this project."""
     project_ = q.project(slug)
     if project_ is None:
         abort(404)
@@ -114,6 +114,7 @@ def activity(slug):
     session = q.get_session()
     recent_revisions = (
         session.query(db.Revision)
+        .options(orm.defer(db.Revision.content))
         .filter_by(project_id=project_.id)
         .order_by(db.Revision.created.desc())
         .limit(100)

--- a/ambuda/views/proofing/user.py
+++ b/ambuda/views/proofing/user.py
@@ -9,6 +9,7 @@ from flask import (
 
 from flask_login import current_user, login_required
 from flask_wtf import FlaskForm
+from sqlalchemy import orm
 from wtforms import BooleanField
 from wtforms import StringField
 from wtforms.widgets import TextArea
@@ -50,13 +51,28 @@ def activity(username):
         abort(404)
 
     session = q.get_session()
-    user_revisions = session.query(db.Revision).filter_by(author_id=user_.id).all()
-    hm = heatmap.create(r.created.date() for r in user_revisions)
+    recent_revisions = (
+        session.query(db.Revision)
+        .filter_by(author_id=user_.id)
+        .order_by(db.Revision.created.desc())
+        .options(orm.defer("content"))
+        .all()
+    )
+    recent_projects = (
+        session.query(db.Project)
+        .filter_by(creator_id=user_.id)
+        .order_by(db.Project.created_at.desc())
+        .all()
+    )
+
+    recent_activity = [("revision", r.created, r) for r in recent_revisions]
+    recent_activity += [("project", p.created_at, p) for p in recent_projects]
+    hm = heatmap.create(x[1].date() for x in recent_activity)
 
     return render_template(
         "proofing/user/activity.html",
         user=user_,
-        user_revisions=user_revisions,
+        recent_activity=recent_activity,
         heatmap=hm,
     )
 

--- a/ambuda/views/proofing/user.py
+++ b/ambuda/views/proofing/user.py
@@ -53,9 +53,9 @@ def activity(username):
     session = q.get_session()
     recent_revisions = (
         session.query(db.Revision)
+        .options(orm.defer(db.Revision.content))
         .filter_by(author_id=user_.id)
         .order_by(db.Revision.created.desc())
-        .options(orm.defer("content"))
         .all()
     )
     recent_projects = (


### PR DESCRIPTION
This updates our change logs to include information about created
projects. Our logs now include most kinds of proofing changes, and we
can add others (such as edits to project metadata) in the future.

<img width="660" alt="image" src="https://user-images.githubusercontent.com/1429776/187852335-cfcaf5e7-0f48-4cf7-9800-cf8851cd5359.png">