### PR TITLE
Add health checks for production deploy

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -86,7 +86,7 @@ def deploy_to_commit(_, pointer: str):
         # fails, we'll affect the production application.
         # FIXME: but, what if we upgrade then app restart fails? Should we stop
         # the prod server first? Surely there's a saner way to manage this.
-        upgrade_db(_)
+        c.run("make upgrade")
 
     print("Restarting application ...")
     restart_application(_)
@@ -94,7 +94,8 @@ def deploy_to_commit(_, pointer: str):
     print("Restarting Celery task runner ...")
     restart_celery(_)
 
-    print("Complete.")
+    c.local("python test_prod.py")
+    print("Deploy complete")
 
 
 @task
@@ -110,12 +111,6 @@ def rollback(_, commit):
     :param commit: the commit SHA to roll back to.
     """
     deploy_to_commit(_, commit)
-
-
-def upgrade_db(_):
-    """Upgrade to the latest database migration."""
-    with c.prefix("source env/bin/activate"):
-        c.run("alembic upgrade head")
 
 
 @task

--- a/test_prod.py
+++ b/test_prod.py
@@ -25,12 +25,6 @@ URLS_200 = [
     "/tools/dictionaries/",
 ]
 
-URLS_404 = [
-    "/dictionaries/unknown",
-    "/texts/mahabharatam/unknown",
-    "/texts/unknown",
-]
-
 
 def _ok(s) -> str:
     print(f"\033[92m[  OK  ] {s}\033[0m")
@@ -53,21 +47,7 @@ def check_200() -> bool:
     return ok
 
 
-def check_404() -> bool:
-    ok = True
-    for path in URLS_404:
-        url = f"https://ambuda.org{path}"
-        resp = requests.get(url)
-        if resp.status_code == 404:
-            _ok(f"HTTP 404 {url}")
-        else:
-            _fail(f"HTTP 404 {url}")
-            ok = False
-    return ok
-
-
 if __name__ == "__main__":
-    ok_200 = check_200()
-    ok_404 = check_404()
-    if not (ok_200 and ok_404):
+    ok = check_200()
+    if not ok:
         sys.exit(1)

--- a/test_prod.py
+++ b/test_prod.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 
-"""A basic test suite to ensure that prod is loading correctly."""
+"""A basic test suite to ensure that prod is loading correctly.
+
+We use this in our deploy script to check the basic health of the site.
+"""
+
+import sys
 
 import requests
 
@@ -8,14 +13,16 @@ import requests
 URLS_200 = [
     "/",
     "/api/dictionaries/vacaspatyam/nara",
+    "/texts/",
+    "/texts/mahabharatam/1.1",
+    "/texts/mahabharatam/18.5",
     "/tools/dictionaries/",
     "/tools/dictionaries/apte/nara",
     "/tools/dictionaries/mw/nara",
     "/tools/dictionaries/shabdakalpadruma/nara",
     "/tools/dictionaries/vacaspatyam/nara",
-    "/texts/",
-    "/texts/mahabharatam/1.1",
-    "/texts/mahabharatam/18.5",
+    "/proofing/",
+    "/tools/dictionaries/",
 ]
 
 URLS_404 = [
@@ -33,7 +40,8 @@ def _fail(s) -> str:
     print(f"\033[91m[ FAIL ] {s}\033[0m")
 
 
-def check_200():
+def check_200() -> bool:
+    ok = True
     for path in URLS_200:
         url = f"https://ambuda.org{path}"
         resp = requests.get(url)
@@ -41,9 +49,12 @@ def check_200():
             _ok(f"HTTP 200 {url}")
         else:
             _fail(f"HTTP 200 {url}")
+            ok = False
+    return ok
 
 
-def check_404():
+def check_404() -> bool:
+    ok = True
     for path in URLS_404:
         url = f"https://ambuda.org{path}"
         resp = requests.get(url)
@@ -51,8 +62,12 @@ def check_404():
             _ok(f"HTTP 404 {url}")
         else:
             _fail(f"HTTP 404 {url}")
+            ok = False
+    return ok
 
 
 if __name__ == "__main__":
-    check_200()
-    check_404()
+    ok_200 = check_200()
+    ok_404 = check_404()
+    if not (ok_200 and ok_404):
+        sys.exit(1)


### PR DESCRIPTION
ambuda.org was down for about 8 hours.

Timeline
--------
- Arun runs `fab deploy` around midnight PST.
- The site goes down (nginx 502).
- Akshay notices around 12:10 am PST.
- Shreevatsa pings arun in the morning around 7 am PST.
- Arun brings the site back up.

Root cause
----------
PR https://github.com/ambuda-org/ambuda/pull/310 defines a new moderator role. The server check-fails if the role
isn't available. Our deploy script restarts the application but gives no
indication if the deploy is in a healthy state:

```
======================= 255 passed, 2 warnings in 10.40s =======================
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Restarting application ...
Restarting Celery task runner ...
Complete.
```

Prevention
----------
Running `make upgrade` on the server fixes the issue.

There are dozens of ways to mitigate this kind of issue, all of varying
levels of feasibility and importance. This commit adds two simple
ones:

- Run `make upgrade` as part of the prod deploy.
- Add an explicit test of production at the end of the deploy script.

Test plan
---------

Ran the script.

<img width="641" alt="image" src="https://user-images.githubusercontent.com/1429776/187951259-f03ccb99-8ab6-476d-991f-c67135c46650.png">
