### PR TITLE
Add support for batch OCR

### DIFF
--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -147,7 +147,6 @@ def _check_bot_user(session) -> list[str]:
 def check_database(database_uri: str):
     errors = _check_app_schema_matches_db_schema(database_uri)
 
-    engine = create_engine(database_uri)
     session = q.get_session()
     errors += _check_lookup_tables(session)
     errors += _check_bot_user(session)

--- a/ambuda/checks.py
+++ b/ambuda/checks.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.schema import Column
 from sqlalchemy import inspect
 
+from ambuda import consts
 from ambuda import database as db
 from ambuda import enums
 from ambuda import queries as q
@@ -106,9 +107,7 @@ def _check_app_schema_matches_db_schema(database_uri: str) -> list[str]:
     return errors
 
 
-def _check_lookup_tables(database_uri: str) -> list[str]:
-    engine = create_engine(database_uri)
-    session = q.get_session()
+def _check_lookup_tables(session) -> list[str]:
     lookups = [
         (enums.SitePageStatus, db.PageStatus),
         (enums.SiteRole, db.Role),
@@ -135,9 +134,23 @@ def _check_lookup_tables(database_uri: str) -> list[str]:
     return errors
 
 
+def _check_bot_user(session) -> list[str]:
+    """Check that the ambuda-bot user exists."""
+    username = consts.BOT_USERNAME
+    bot_user = session.query(db.User).filter_by(username=username).first()
+    if bot_user:
+        return []
+    else:
+        return [f'Bot user "{username}" does not exist.']
+
+
 def check_database(database_uri: str):
     errors = _check_app_schema_matches_db_schema(database_uri)
-    errors += _check_lookup_tables(database_uri)
+
+    engine = create_engine(database_uri)
+    session = q.get_session()
+    errors += _check_lookup_tables(session)
+    errors += _check_bot_user(session)
 
     if errors:
         _warn("The data tables defined in your application code don't match the")
@@ -146,15 +159,17 @@ def check_database(database_uri: str):
         _warn()
         _warn("    make upgrade")
         _warn()
+        _warn("Specific errors are:")
+        _warn()
+        for error in errors:
+            _warn(f"- {error}")
+        _warn()
         _warn("For more information, see our official docs at:")
         _warn()
         _warn("    https://ambuda.readthedocs.io/en/latest/managing-the-database.html")
         _warn()
         _warn("If the error persists, please ping the #backend channel on the")
         _warn("Ambuda Discord server (https://discord.gg/7rGdTyWY7Z).")
-        _warn()
-        for error in errors:
-            _warn(f"- {error}")
         sys.exit(1)
     else:
         # Style the output to match Flask's styling.

--- a/ambuda/consts.py
+++ b/ambuda/consts.py
@@ -24,3 +24,5 @@ TEXT_CATEGORIES = {
         "catuhshloki",
     ],
 }
+
+BOT_USERNAME = "ambuda-bot"

--- a/ambuda/seed/lookup/__main__.py
+++ b/ambuda/seed/lookup/__main__.py
@@ -1,6 +1,8 @@
 from ambuda.seed.lookup import page_status
 from ambuda.seed.lookup import role
+from ambuda.seed.lookup import create_bot_user
 
 
 page_status.run()
 role.run()
+create_bot_user.run()

--- a/ambuda/seed/lookup/create_bot_user.py
+++ b/ambuda/seed/lookup/create_bot_user.py
@@ -1,0 +1,37 @@
+import os
+
+from sqlalchemy.orm import Session
+
+from ambuda import consts
+from ambuda import database as db
+from ambuda.enums import SitePageStatus
+from ambuda.seed.utils.itihasa_utils import create_db
+
+import logging
+
+
+def _create_bot_user(session):
+    try:
+        password = os.environ["AMBUDA_BOT_PASSWORD"]
+    except KeyError:
+        raise ValueError("Please set the AMBUDA_BOT_PASSWORD environment variable.")
+
+    user = db.User(username=consts.BOT_USERNAME, email="bot@ambuda.org")
+    user.set_password(password)
+    session.add(user)
+    session.commit()
+
+
+def run():
+    """Create page statuses iff they don't exist already."""
+    engine = create_db()
+    logging.debug("Creating bot user ...")
+    with Session(engine) as session:
+        user = session.query(db.User).filter_by(username=consts.BOT_USERNAME).first()
+        if not user:
+            _create_bot_user(session)
+    logging.debug("Done.")
+
+
+if __name__ == "__main__":
+    run()

--- a/ambuda/static/js/html-poller.js
+++ b/ambuda/static/js/html-poller.js
@@ -1,3 +1,7 @@
+/**
+ * Poll the given URL every 5 seconds and replace this component's innerHTML
+ * with the result.
+ */
 export default (url) => ({
   init() {
     // Use an arrow function so that `this` is bound to the Alpine component.

--- a/ambuda/static/js/html-poller.js
+++ b/ambuda/static/js/html-poller.js
@@ -1,0 +1,11 @@
+export default (url) => ({
+  init() {
+    // Use an arrow function so that `this` is bound to the Alpine component.
+    // If we use `function`, `this` will be bound to the function.
+    setInterval(async () => {
+      const resp = await fetch(url);
+      const progress = await resp.text();
+      this.$root.innerHTML = progress;
+    }, 5000);
+  }
+});

--- a/ambuda/static/js/html-poller.js
+++ b/ambuda/static/js/html-poller.js
@@ -11,5 +11,5 @@ export default (url) => ({
       const progress = await resp.text();
       this.$root.innerHTML = progress;
     }, 5000);
-  }
+  },
 });

--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -3,12 +3,14 @@
 import { $ } from './core.ts';
 import Dictionary from './dictionary';
 import HamburgerButton from './hamburger-button';
+import HTMLPoller from './html-poller';
 import Reader from './reader';
 import Proofer from './proofer';
 import SortableList from './sortable-list';
 
 window.addEventListener('alpine:init', () => {
   Alpine.data('dictionary', Dictionary);
+  Alpine.data('htmlPoller', HTMLPoller);
   Alpine.data('reader', Reader);
   Alpine.data('proofer', Proofer);
   Alpine.data('sortableList', SortableList);

--- a/ambuda/tasks/__init__.py
+++ b/ambuda/tasks/__init__.py
@@ -22,6 +22,9 @@ app = Celery(
     "ambuda-tasks",
     backend=redis_url,
     broker=redis_url,
-    include=["ambuda.tasks.projects"],
+    include=[
+        "ambuda.tasks.projects",
+        "ambuda.tasks.ocr",
+    ],
 )
 app.conf.update(task_serializer="json")

--- a/ambuda/tasks/__init__.py
+++ b/ambuda/tasks/__init__.py
@@ -27,4 +27,9 @@ app = Celery(
         "ambuda.tasks.ocr",
     ],
 )
-app.conf.update(task_serializer="json")
+app.conf.update(
+    # Run all tasks asynchronously by default.
+    task_always_eager=False,
+    # Force arguments to be plain data by requiring them to be JSON-compatible.
+    task_serializer="json",
+)

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -29,7 +29,7 @@ def _run_ocr_for_page_inner(
     with flask_app.app_context():
         bot_user = q.user(consts.BOT_USERNAME)
         if bot_user is None:
-            raise ValueError(f'User "{bot_user}" is not defined.')
+            raise ValueError(f'User "{consts.BOT_USERNAME}" is not defined.')
 
         # The actual API call.
         image_path = get_page_image_filepath(project_slug, page_slug)
@@ -67,7 +67,7 @@ def run_ocr_for_page(
     )
 
 
-def run_ocr_for_book(
+def run_ocr_for_project(
     app_env: str,
     project: db.Project,
 ) -> Optional[GroupResult]:
@@ -75,7 +75,7 @@ def run_ocr_for_book(
 
     Usage:
 
-    >>> r = run_ocr_for_book(...)
+    >>> r = run_ocr_for_project(...)
     >>> progress = r.completed_count() / len(r.results)
 
     :return: the Celery result, or ``None`` if no tasks were run.

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -37,8 +37,6 @@ def _run_ocr_for_page_inner(
         bot_user = q.user(consts.BOT_USERNAME)
 
         try:
-            pass
-            """
             return add_revision(
                 page=page,
                 summary=summary,
@@ -47,7 +45,6 @@ def _run_ocr_for_page_inner(
                 version=0,
                 author_id=bot_user.id,
             )
-            """
         except Exception:
             return -1
 

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -59,7 +59,6 @@ def run_ocr_for_page(
     project_slug: str,
     page_slug: str,
 ):
-    task_status = CeleryTaskStatus(self)
     _run_ocr_for_page_inner(
         app_env,
         project_slug,

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -35,12 +35,16 @@ def _run_ocr_for_page_inner(
         image_path = get_page_image_filepath(project_slug, page_slug)
         ocr_response = google_ocr.run(image_path)
 
-        bounding_boxes_tsv = "\n".join(
-            "\t".join(row) for row in ocr_response.bounding_boxes
-        )
-
+        session = q.get_session()
         project = q.project(project_slug)
         page = q.page(project.id, page_slug)
+
+        page.ocr_bounding_boxes = google_ocr.serialize_bounding_boxes(
+            ocr_response.bounding_boxes
+        )
+        session.add(page)
+        session.commit()
+
         summary = f"Run OCR"
         try:
             return add_revision(

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -1,0 +1,44 @@
+"""Background tasks for proofing projects."""
+
+import time
+
+from celery import group
+
+from ambuda.tasks import app
+from ambuda.tasks.utils import TaskStatus, CeleryTaskStatus
+from ambuda import queries as q
+from config import create_config_only_app
+
+
+def _run_ocr_for_page_inner(project_slug: str, page_slug: str, user_id: int):
+    print(f"{project_slug}, {page_slug}, {user_id}")
+    time.sleep(2)
+    return "done"
+
+
+@app.task(bind=True)
+def run_ocr_for_page(self, **kw):
+    task_status = CeleryTaskStatus(self)
+    _run_ocr_for_page_inner(**kw, task_status=task_status)
+
+
+def _run_ocr_for_book_inner(
+    project_slug: str, app_environment: str, user_id: int, task_status: TaskStatus
+):
+    flask_app = create_config_only_app(app_environment)
+    with flask_app.app_context():
+        project = q.project(project_slug)
+        unedited_pages = [p for p in project.pages if p.version == 0]
+
+    tasks = group(
+        run_ocr_for_page(project_slug, p.slug, user_id) for p in unedited_pages
+    )
+
+
+@app.task(bind=True)
+def run_ocr_for_book(
+    self,
+    **kw,
+):
+    task_status = CeleryTaskStatus(self)
+    _run_ocr_for_book_inner(**kw, task_status=task_status)

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -4,41 +4,68 @@ import time
 
 from celery import group
 
+from ambuda.enums import SitePageStatus
 from ambuda.tasks import app
 from ambuda.tasks.utils import TaskStatus, CeleryTaskStatus
+from ambuda.utils.revisions import add_revision
 from ambuda import queries as q
 from config import create_config_only_app
 
 
-def _run_ocr_for_page_inner(project_slug: str, page_slug: str, user_id: int):
-    print(f"{project_slug}, {page_slug}, {user_id}")
+def _run_ocr_for_page_inner(
+    app_env: str,
+    project_slug: str,
+    page_slug: str,
+    user_id: int,
+    task_status: TaskStatus,
+):
+    """Must run in the application context."""
     time.sleep(2)
-    return "done"
+    flask_app = create_config_only_app(app_env)
+
+    content = f"OCR response for {project_slug}/{page_slug}"
+    with flask_app.app_context():
+        session = q.get_session()
+        project = q.project(project_slug)
+        page = q.page(project.id, page_slug)
+
+        try:
+            add_revision(
+                page=page,
+                summary="Run batch OCR",
+                content=content,
+                status=SitePageStatus.R0,
+                version=1,
+                author_id=user_id,
+            )
+        except Exception:
+            raise ValueError("Could not create revision")
 
 
 @app.task(bind=True)
-def run_ocr_for_page(self, **kw):
-    task_status = CeleryTaskStatus(self)
-    _run_ocr_for_page_inner(**kw, task_status=task_status)
-
-
-def _run_ocr_for_book_inner(
-    project_slug: str, app_environment: str, user_id: int, task_status: TaskStatus
+def run_ocr_for_page(
+    self, *, app_env: str, project_slug: str, page_slug: str, user_id: int
 ):
-    flask_app = create_config_only_app(app_environment)
+    task_status = CeleryTaskStatus(self)
+    _run_ocr_for_page_inner(
+        app_env, project_slug, page_slug, user_id, task_status=task_status
+    )
+
+
+@app.task(bind=True)
+def run_ocr_for_book(self, *, app_env: str, project_slug: str, user_id: int):
+    flask_app = create_config_only_app(app_env)
     with flask_app.app_context():
         project = q.project(project_slug)
         unedited_pages = [p for p in project.pages if p.version == 0]
 
     tasks = group(
-        run_ocr_for_page(project_slug, p.slug, user_id) for p in unedited_pages
+        run_ocr_for_page.s(
+            app_env=app_env,
+            project_slug=project_slug,
+            page_slug=p.slug,
+            user_id=user_id,
+        )
+        for p in unedited_pages
     )
-
-
-@app.task(bind=True)
-def run_ocr_for_book(
-    self,
-    **kw,
-):
-    task_status = CeleryTaskStatus(self)
-    _run_ocr_for_book_inner(**kw, task_status=task_status)
+    tasks.apply_async()

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -35,7 +35,7 @@ def _run_ocr_for_page_inner(
                 summary="Run batch OCR",
                 content=content,
                 status=SitePageStatus.R0,
-                version=1,
+                version=0,
                 author_id=user_id,
             )
         except Exception:

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -33,7 +33,11 @@ def _run_ocr_for_page_inner(
 
         # The actual API call.
         image_path = get_page_image_filepath(project_slug, page_slug)
-        content = google_ocr.full_text_annotation(image_path)
+        ocr_response = google_ocr.run(image_path)
+
+        bounding_boxes_tsv = "\n".join(
+            "\t".join(row) for row in ocr_response.bounding_boxes
+        )
 
         project = q.project(project_slug)
         page = q.page(project.id, page_slug)
@@ -42,7 +46,7 @@ def _run_ocr_for_page_inner(
             return add_revision(
                 page=page,
                 summary=summary,
-                content=content,
+                content=ocr_response.text_content,
                 status=SitePageStatus.R0,
                 version=0,
                 author_id=bot_user.id,

--- a/ambuda/tasks/ocr.py
+++ b/ambuda/tasks/ocr.py
@@ -4,6 +4,8 @@ import time
 
 from celery import group
 
+from ambuda import consts
+from ambuda import database as db
 from ambuda.enums import SitePageStatus
 from ambuda.tasks import app
 from ambuda.tasks.utils import TaskStatus, CeleryTaskStatus
@@ -16,27 +18,29 @@ def _run_ocr_for_page_inner(
     app_env: str,
     project_slug: str,
     page_slug: str,
-    user_id: int,
+    username: str,
     task_status: TaskStatus,
 ):
     """Must run in the application context."""
     time.sleep(2)
     flask_app = create_config_only_app(app_env)
 
+    summary = f"Run OCR"
     content = f"OCR response for {project_slug}/{page_slug}"
     with flask_app.app_context():
         session = q.get_session()
         project = q.project(project_slug)
         page = q.page(project.id, page_slug)
+        bot_user = q.user(consts.BOT_USERNAME)
 
         try:
             add_revision(
                 page=page,
-                summary="Run batch OCR",
+                summary=summary,
                 content=content,
                 status=SitePageStatus.R0,
                 version=0,
-                author_id=user_id,
+                author_id=bot_user.id,
             )
         except Exception:
             raise ValueError("Could not create revision")
@@ -44,11 +48,11 @@ def _run_ocr_for_page_inner(
 
 @app.task(bind=True)
 def run_ocr_for_page(
-    self, *, app_env: str, project_slug: str, page_slug: str, user_id: int
+    self, *, app_env: str, project_slug: str, page_slug: str, username: str
 ):
     task_status = CeleryTaskStatus(self)
     _run_ocr_for_page_inner(
-        app_env, project_slug, page_slug, user_id, task_status=task_status
+        app_env, project_slug, page_slug, username, task_status=task_status
     )
 
 
@@ -56,15 +60,20 @@ def run_ocr_for_page(
 def run_ocr_for_book(self, *, app_env: str, project_slug: str, user_id: int):
     flask_app = create_config_only_app(app_env)
     with flask_app.app_context():
+        session = q.get_session()
         project = q.project(project_slug)
         unedited_pages = [p for p in project.pages if p.version == 0]
+
+        user = session.query(db.User).filter_by(id=user_id).first()
+        if not user:
+            raise ValueError("The requesting user does not exist.")
 
     tasks = group(
         run_ocr_for_page.s(
             app_env=app_env,
             project_slug=project_slug,
             page_slug=p.slug,
-            user_id=user_id,
+            username=user.username,
         )
         for p in unedited_pages
     )

--- a/ambuda/tasks/projects.py
+++ b/ambuda/tasks/projects.py
@@ -7,82 +7,13 @@ from pathlib import Path
 # package called `fitz` (https://pypi.org/project/fitz/) that is completely
 # unrelated to PDF parsing.
 import fitz
-from celery import states
 from slugify import slugify
 
 from ambuda import database as db
 from ambuda import queries as q
 from ambuda.tasks import app
+from ambuda.tasks.utils import TaskStatus, CeleryTaskStatus
 from config import create_config_only_app
-
-
-class TaskStatus:
-    """Helper class to track progress on a task.
-
-    - For Celery tasks, use CeleryTaskStatus.
-    - For local usage (unit tests, CLI, ...), use a LocalTaskStatus instead.
-    """
-
-    def progress(self, current: int, total: int):
-        """Update the task's progress.
-
-        :param current: progress numerator
-        :param total: progress denominator
-        """
-        raise NotImplementedError
-
-    def success(self, num_pages: int, slug: str):
-        """Mark the task as a success.
-
-        # FIXME(arun): make this API more generic.
-        """
-        raise NotImplementedError
-
-    def failure(self, message: str):
-        """Mark the task as failed."""
-        raise NotImplementedError
-
-
-class CeleryTaskStatus(TaskStatus):
-    """Helper class to track progress on a Celery task."""
-
-    def __init__(self, task):
-        self.task = task
-
-    def progress(self, current: int, total: int):
-        """Update the task's progress.
-
-        :param current: progress numerator
-        :param total: progress denominator
-        """
-        # Celery doesn't have a "PROGRESS" state, so just use a hard-coded string.
-        self.task.update_state(
-            state="PROGRESS", meta={"current": current, "total": total}
-        )
-
-    def success(self, num_pages: int, slug: str):
-        """Mark the task as a success."""
-        self.task.update_state(
-            state=states.SUCCESS,
-            meta={"current": num_pages, "total": num_pages, "slug": slug},
-        )
-
-    def failure(self, message: str):
-        """Mark the task as failed."""
-        self.task.update_state(state=states.FAILURE, meta={"message": message})
-
-
-class LocalTaskStatus(TaskStatus):
-    """Helper class to track progress on a task running locally."""
-
-    def progress(self, current: int, total: int):
-        logging.info(f"{current} / {total} complete")
-
-    def success(self, num_pages: int, slug: str):
-        logging.info(f"Succeeded. Project is at {slug}.")
-
-    def failure(self, message: str):
-        logging.info(f"Failed. ({message})")
 
 
 def _split_pdf_into_pages(

--- a/ambuda/tasks/utils.py
+++ b/ambuda/tasks/utils.py
@@ -1,0 +1,72 @@
+import logging
+
+from celery import states
+
+
+class TaskStatus:
+    """Helper class to track progress on a task.
+
+    - For Celery tasks, use CeleryTaskStatus.
+    - For local usage (unit tests, CLI, ...), use a LocalTaskStatus instead.
+    """
+
+    def progress(self, current: int, total: int):
+        """Update the task's progress.
+
+        :param current: progress numerator
+        :param total: progress denominator
+        """
+        raise NotImplementedError
+
+    def success(self, num_pages: int, slug: str):
+        """Mark the task as a success.
+
+        # FIXME(arun): make this API more generic.
+        """
+        raise NotImplementedError
+
+    def failure(self, message: str):
+        """Mark the task as failed."""
+        raise NotImplementedError
+
+
+class CeleryTaskStatus(TaskStatus):
+    """Helper class to track progress on a Celery task."""
+
+    def __init__(self, task):
+        self.task = task
+
+    def progress(self, current: int, total: int):
+        """Update the task's progress.
+
+        :param current: progress numerator
+        :param total: progress denominator
+        """
+        # Celery doesn't have a "PROGRESS" state, so just use a hard-coded string.
+        self.task.update_state(
+            state="PROGRESS", meta={"current": current, "total": total}
+        )
+
+    def success(self, num_pages: int, slug: str):
+        """Mark the task as a success."""
+        self.task.update_state(
+            state=states.SUCCESS,
+            meta={"current": num_pages, "total": num_pages, "slug": slug},
+        )
+
+    def failure(self, message: str):
+        """Mark the task as failed."""
+        self.task.update_state(state=states.FAILURE, meta={"message": message})
+
+
+class LocalTaskStatus(TaskStatus):
+    """Helper class to track progress on a task running locally."""
+
+    def progress(self, current: int, total: int):
+        logging.info(f"{current} / {total} complete")
+
+    def success(self, num_pages: int, slug: str):
+        logging.info(f"Succeeded. Project is at {slug}.")
+
+    def failure(self, message: str):
+        logging.info(f"Failed. ({message})")

--- a/ambuda/templates/include/ocr-progress.html
+++ b/ambuda/templates/include/ocr-progress.html
@@ -20,7 +20,7 @@
 
 {% elif status == 'SUCCESS' %}
   {{ progress_bar(100) }}
-  <p>OCR complete.</p>
+  <p>Done. (Processed {{ current }} of {{ total }} unedited pages.)</p>
 
 {% else %}
   {{ progress_bar(0) }}

--- a/ambuda/templates/include/ocr-progress.html
+++ b/ambuda/templates/include/ocr-progress.html
@@ -1,0 +1,28 @@
+{% import 'macros/components.html' as components %}
+
+{% macro progress_bar(percent) %}
+<div class="my-4 rounded w-full bg-slate-100 h-4">
+  <div class="rounded bg-green-300 h-4" style="width: {{ percent }}%">&nbsp;</div>
+</div>
+{% endmacro %}
+
+{# kwargs: current, total, percent #}
+{% if status == 'FAILURE' %}
+  {% call components.div_warning() %}
+  <p class="!mb-0">We weren't able to complete OCR on this project. If you
+  believe this is an error, please <a href="{{ url_for('about.contact') }}">let
+  us know</a> and we'll fix the error as soon as we can.
+  {% endcall %}
+
+{% elif status == 'PROGRESS' %}
+  {{ progress_bar(percent) }}
+  <p>Processed {{ current }} of {{ total }} unedited pages.</p>
+
+{% elif status == 'SUCCESS' %}
+  {{ progress_bar(100) }}
+  <p>OCR complete.</p>
+
+{% else %}
+  {{ progress_bar(0) }}
+  <p>Beginning OCR &hellip;</p>
+{% endif %}

--- a/ambuda/templates/proofing/create-project-post.html
+++ b/ambuda/templates/proofing/create-project-post.html
@@ -15,7 +15,7 @@
 
 <p class="text-sm">(This page updates every 5 seconds.)</p>
 
-<div id="progress">
+<div x-data="htmlPoller('/proofing/status/{{ task_id }}')">
   {% with current=current, total=total, percent=percent, slug=slug, status=status %}
     {% include 'include/task-progress.html' %}
   {% endwith %}
@@ -23,13 +23,6 @@
 </div>
 
 <script type="text/javascript">
-  const taskId = '{{ task_id }}';
-  setInterval(async function() {
-    const url = `/proofing/status/${taskId}`;
-    const resp = await fetch(url);
-    const progress = await resp.text();
-    document.querySelector('#progress').innerHTML = progress;
-  }, 5000);
 </script>
 
 {% endblock %}

--- a/ambuda/templates/proofing/create-project-post.html
+++ b/ambuda/templates/proofing/create-project-post.html
@@ -15,7 +15,8 @@
 
 <p class="text-sm">(This page updates every 5 seconds.)</p>
 
-<div x-data="htmlPoller('/proofing/status/{{ task_id }}')">
+{% set url = url_for('proofing.create_project_status', task_id=task_id) %}
+<div x-data="htmlPoller('{{ url }}')">
   {% with current=current, total=total, percent=percent, slug=slug, status=status %}
     {% include 'include/task-progress.html' %}
   {% endwith %}

--- a/ambuda/templates/proofing/projects/batch-ocr-post.html
+++ b/ambuda/templates/proofing/projects/batch-ocr-post.html
@@ -10,9 +10,10 @@
 {{ m.project_header_nested('OCR', project) }}
 {{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
 
-<div id="progress" x-data="htmlPoller('aoeu')">
+{% set url = url_for('proofing.project.batch_ocr_status', task_id=task_id) %}
+<div id="progress" x-data="htmlPoller('{{ url }}')">
   {% with current=current, total=total, percent=percent, slug=slug, status=status %}
-    {% include 'include/task-progress.html' %}
+    {% include 'include/ocr-progress.html' %}
   {% endwith %}
 </div>
 {% endblock %}

--- a/ambuda/templates/proofing/projects/batch-ocr-post.html
+++ b/ambuda/templates/proofing/projects/batch-ocr-post.html
@@ -2,18 +2,17 @@
 {% from "macros/forms.html" import field %}
 {% import "macros/proofing.html" as m %}
 
+
 {% block title %}OCR {{ project.title }} | Ambuda{% endblock %}
 
-{% block content %}
 
+{% block content %}
 {{ m.project_header_nested('OCR', project) }}
 {{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
 
-<div class="prose">
-  <p>Use this simple search form to find typos across this project.</p>
-
-  <form method="POST">
-      <input class="btn btn-submit" type="submit" value="Run OCR"></input>
-  </form>
+<div id="progress" x-data="htmlPoller('aoeu')">
+  {% with current=current, total=total, percent=percent, slug=slug, status=status %}
+    {% include 'include/task-progress.html' %}
+  {% endwith %}
 </div>
 {% endblock %}

--- a/ambuda/templates/proofing/projects/batch-ocr.html
+++ b/ambuda/templates/proofing/projects/batch-ocr.html
@@ -9,9 +9,9 @@
 {{ m.project_header_nested('OCR', project) }}
 {{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
 
-{% if running_ocr %}
+{% if progress is not none %}
 <div class="prose">
-  <p>OCR is in progress.</p>
+  <p>OCR is in progress. {{ progress }}</p>
 </div>
 {% else %}
 <div class="prose">

--- a/ambuda/templates/proofing/projects/batch-ocr.html
+++ b/ambuda/templates/proofing/projects/batch-ocr.html
@@ -14,7 +14,7 @@
 {{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
 
 <div class="prose">
-  <p>Use this simple search form to find typos across this project.</p>
+  <p>Click the button below to run OCR on every unedited page.</p>
 
   <form method="POST">
       <input class="btn btn-submit" type="submit" value="Run OCR"></input>

--- a/ambuda/templates/proofing/projects/batch-ocr.html
+++ b/ambuda/templates/proofing/projects/batch-ocr.html
@@ -1,10 +1,14 @@
 {% extends 'proofing/base.html' %}
+{% import "macros/components.html" as components %}
 {% from "macros/forms.html" import field %}
 {% import "macros/proofing.html" as m %}
 
+
 {% block title %}OCR {{ project.title }} | Ambuda{% endblock %}
 
+
 {% block content %}
+{{ components.flash_messages() }}
 
 {{ m.project_header_nested('OCR', project) }}
 {{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}

--- a/ambuda/templates/proofing/projects/batch-ocr.html
+++ b/ambuda/templates/proofing/projects/batch-ocr.html
@@ -1,0 +1,25 @@
+{% extends 'proofing/base.html' %}
+{% from "macros/forms.html" import field %}
+{% import "macros/proofing.html" as m %}
+
+{% block title %}OCR {{ project.title }} | Ambuda{% endblock %}
+
+{% block content %}
+
+{{ m.project_header_nested('OCR', project) }}
+{{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
+
+{% if running_ocr %}
+<div class="prose">
+  <p>OCR is in progress.</p>
+</div>
+{% else %}
+<div class="prose">
+  <p>Use this simple search form to find typos across this project.</p>
+
+  <form method="POST">
+      <input class="btn btn-submit" type="submit" value="Run OCR"></input>
+  </form>
+</div>
+{% endif %}
+{% endblock %}

--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -14,10 +14,12 @@
 {{ m.project_header_nested('Edit', project) }}
 {{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
+{% set ocr_url = url_for("proofing.project.batch_ocr", slug=project.slug)  %}
 
 <div class="prose">
 <p>We'll add more useful tools here soon. For now, you can <a href="{{
-    search_url }}">search the project</a> or edit its metadata:</p>
+search_url }}">search the project</a>, <a href="{{ ocr_url }}">run batch OCR</a>,
+or edit its metadata:</p>
 </div>
 
 {{ components.flash_messages() }}

--- a/ambuda/utils/assets.py
+++ b/ambuda/utils/assets.py
@@ -10,8 +10,7 @@ import functools
 import hashlib
 from pathlib import Path
 
-from flask import url_for
-
+from flask import url_for, current_app
 
 STATIC_DIR = Path(__file__).parent.parent / "static"
 assert STATIC_DIR.exists(), "Could not find static directory."
@@ -36,3 +35,12 @@ def hashed_static(filename: str) -> str:
 
     base_url = url_for("static", filename=filename)
     return f"{base_url}?h={hash_prefix}"
+
+
+def get_page_image_filepath(project_slug: str, page_slug: str) -> Path:
+    """Get the location of the given image on disk.
+
+    This function must run within an app context.
+    """
+    image_dir = Path(current_app.config["UPLOAD_FOLDER"]) / "projects" / project_slug
+    return image_dir / "pages" / f"{page_slug}.jpg"

--- a/ambuda/utils/google_ocr.py
+++ b/ambuda/utils/google_ocr.py
@@ -7,21 +7,20 @@
 # Billing: https://console.cloud.google.com/billing/
 
 
-import dataclass
 import io
-import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from google.cloud import vision
-from google.protobuf.json_format import MessageToDict
 from google.cloud.vision_v1 import AnnotateImageResponse
 
 
 @dataclass
 class OcrResponse:
+    #: A slightly sanitized version of the OCR's plain-text output.
     text_content: str
-    # Lists of 5-tuples (x1, x2, y1, y2, text)
+    #: Word-level bounding boxes stored as 5-tuples (x1, x2, y1, y2, text).
     bounding_boxes: list[tuple[int, int, int, int, str]]
 
 
@@ -41,15 +40,31 @@ def post_process(text: str) -> str:
     )
 
 
-def prepare_image(file_path):
+def prepare_image(file_path: Path):
+    """Read an image into a protocol buffer for the OCR request."""
     with io.open(file_path, "rb") as file_path:
         content = file_path.read()
     return vision.Image(content=content)
 
 
-def run(file_path: Path) -> str:
-    """Detects document features in the file located in Google Cloud
-    Storage."""
+def serialize_bounding_boxes(boxes: list[tuple[int, int, int, int, str]]) -> str:
+    """Serialize a list of bounding boxes as a TSV."""
+    return "\n".join("\t".join(str(x) for x in row) for row in boxes)
+
+
+def debug_dump_response(response):
+    """A handy debug function that dumps the OCR response to a JSON file."""
+    with open("out.json", "w") as f:
+        f.write(AnnotateImageResponse.to_json(response))
+
+
+def run(file_path: Path) -> OcrResponse:
+    """Run Google OCR over the given image.
+
+    :param file_path: path to the image we'll process with OCR.
+    :return: an OCR response containing the image's text content and
+        bounding boxes.
+    """
     logging.debug("Starting full text annotation: {}".format(file_path))
 
     client = vision.ImageAnnotatorClient()
@@ -59,24 +74,19 @@ def run(file_path: Path) -> str:
     # making English noticeably worse.
     # context = vision.ImageContext(language_hints=['sa'])
     response = client.document_text_detection(image=image)  # , image_context=context)
-
     document = response.full_text_annotation
 
-    # print("Writing as json")
-    # with open("out.json", "w") as f:
-    #     f.write(AnnotateImageResponse.to_json(response))
-
     buf = []
-    boxes = []
+    bounding_boxes = []
     for page in document.pages:
         for block in page.blocks:
             for p in block.paragraphs:
                 for w in p.words:
-                    vertices = w.boundingBox.vertices
-                    xs = [v["x"] for v in vertices]
-                    ys = [v["y"] for v in vertices]
+                    vertices = w.bounding_box.vertices
+                    xs = [v.x for v in vertices]
+                    ys = [v.y for v in vertices]
                     word = "".join(s.text for s in w.symbols)
-                    boxes.append((min(xs), min(ys), max(xs), max(ys), word))
+                    bounding_boxes.append((min(xs), min(ys), max(xs), max(ys), word))
 
                     for s in w.symbols:
                         buf.append(s.text)

--- a/ambuda/utils/google_ocr.py
+++ b/ambuda/utils/google_ocr.py
@@ -9,11 +9,12 @@
 
 import io
 import json
+import logging
+from pathlib import Path
+
 from google.cloud import vision
 from google.protobuf.json_format import MessageToDict
 from google.cloud.vision_v1 import AnnotateImageResponse
-
-import logging
 
 
 def post_process(text: str) -> str:
@@ -38,7 +39,7 @@ def prepare_image(file_path):
     return vision.Image(content=content)
 
 
-def full_text_annotation(file_path):
+def full_text_annotation(file_path: Path) -> str:
     """Detects document features in the file located in Google Cloud
     Storage."""
     logging.debug("Starting full text annotation: {}".format(file_path))

--- a/ambuda/utils/revisions.py
+++ b/ambuda/utils/revisions.py
@@ -1,0 +1,50 @@
+from sqlalchemy import update
+
+from ambuda import database as db, queries as q
+
+
+class EditException(Exception):
+    """Raised if a user's attempt to edit a page fails."""
+
+    pass
+
+
+def add_revision(
+    page: db.Page, summary: str, content: str, status: str, version: int, author_id: int
+) -> int:
+    """Add a new revision for a page."""
+    # If this doesn't update any rows, there's an edit conflict.
+    # Details: https://gist.github.com/shreevatsa/237bd6592771caadecc68c9515403bc3
+    # FIXME: rather than do this on the application side, do an `exists` query
+    # FIXME: instead? Not sure if this is a clear win, but worth thinking about.
+
+    # FIXME: Check for `proofreading` user permission before allowing changes
+    session = q.get_session()
+    status_ids = {s.name: s.id for s in q.page_statuses()}
+    new_version = version + 1
+    result = session.execute(
+        update(db.Page)
+        .where((db.Page.id == page.id) & (db.Page.version == version))
+        .values(version=new_version, status_id=status_ids[status])
+    )
+    session.commit()
+
+    num_rows_changed = result.rowcount
+    if num_rows_changed == 0:
+        raise EditException("Edit conflict")
+
+    # Must be 1 since there's exactly one page with the given page ID.
+    # If this fails, the application data is in a weird state.
+    assert num_rows_changed == 1
+
+    revision_ = db.Revision(
+        project_id=page.project_id,
+        page_id=page.id,
+        summary=summary,
+        content=content,
+        author_id=author_id,
+        status_id=status_ids[status],
+    )
+    session.add(revision_)
+    session.commit()
+    return new_version

--- a/ambuda/utils/revisions.py
+++ b/ambuda/utils/revisions.py
@@ -31,7 +31,7 @@ def add_revision(
 
     num_rows_changed = result.rowcount
     if num_rows_changed == 0:
-        raise EditException("Edit conflict")
+        raise EditException(f"Edit conflict {page.slug}, {version}")
 
     # Must be 1 since there's exactly one page with the given page ID.
     # If this fails, the application data is in a weird state.

--- a/ambuda/views/proofing/page.py
+++ b/ambuda/views/proofing/page.py
@@ -209,5 +209,5 @@ def ocr(project_slug, page_slug):
         abort(404)
 
     image_path = get_page_image_filepath(project_slug, page_slug)
-    result = google_ocr.full_text_annotation(image_path)
-    return result
+    ocr_response = google_ocr.run(image_path)
+    return ocr_response.text_content

--- a/ambuda/views/proofing/page.py
+++ b/ambuda/views/proofing/page.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from flask import render_template, flash, current_app, send_file, Blueprint
 from flask_login import login_required, current_user
 from flask_wtf import FlaskForm
@@ -10,6 +8,7 @@ from wtforms.widgets import TextArea
 
 from ambuda import database as db, queries as q
 from ambuda.utils import google_ocr
+from ambuda.utils.assets import get_page_image_filepath
 from ambuda.utils.diff import revision_diff
 from ambuda.utils.revisions import add_revision, EditException
 from ambuda.views.api import bp as api
@@ -17,12 +16,6 @@ from ambuda.views.site import bp as site
 
 
 bp = Blueprint("page", __name__)
-
-
-def _get_image_filesystem_path(project_slug: str, page_slug: str) -> Path:
-    """Get the location of the given image on disk."""
-    image_dir = Path(current_app.config["UPLOAD_FOLDER"]) / "projects" / project_slug
-    return image_dir / "pages" / f"{page_slug}.jpg"
 
 
 class EditPageForm(FlaskForm):
@@ -142,7 +135,7 @@ def edit_post(project_slug, page_slug):
 def page_image(project_slug, page_slug):
     # In production, serve this directly via nginx.
     assert current_app.debug
-    image_path = _get_image_filesystem_path(project_slug, page_slug)
+    image_path = get_page_image_filepath(project_slug, page_slug)
     return send_file(image_path)
 
 
@@ -215,6 +208,6 @@ def ocr(project_slug, page_slug):
     if not page_:
         abort(404)
 
-    image_path = _get_image_filesystem_path(project_slug, page_slug)
+    image_path = get_page_image_filepath(project_slug, page_slug)
     result = google_ocr.full_text_annotation(image_path)
     return result

--- a/ambuda/views/proofing/page.py
+++ b/ambuda/views/proofing/page.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from flask import render_template, flash, current_app, send_file, Blueprint
 from flask_login import login_required, current_user
 from flask_wtf import FlaskForm
-from sqlalchemy import update
 from werkzeug.exceptions import abort
 from wtforms import StringField, HiddenField, SelectField
 from wtforms.validators import DataRequired
@@ -12,6 +11,7 @@ from wtforms.widgets import TextArea
 from ambuda import database as db, queries as q
 from ambuda.utils import google_ocr
 from ambuda.utils.diff import revision_diff
+from ambuda.utils.revisions import add_revision, EditException
 from ambuda.views.api import bp as api
 from ambuda.views.site import bp as site
 
@@ -23,12 +23,6 @@ def _get_image_filesystem_path(project_slug: str, page_slug: str) -> Path:
     """Get the location of the given image on disk."""
     image_dir = Path(current_app.config["UPLOAD_FOLDER"]) / "projects" / project_slug
     return image_dir / "pages" / f"{page_slug}.jpg"
-
-
-class EditException(Exception):
-    """Raised if a user's attempt to edit a page fails."""
-
-    pass
 
 
 class EditPageForm(FlaskForm):
@@ -66,47 +60,6 @@ def _prev_cur_next(pages: list[db.Page], slug: str) -> tuple[db.Page, db.Page, d
     cur = pages[i]
     next = pages[i + 1] if i < len(pages) - 1 else None
     return prev, cur, next
-
-
-def add_revision(
-    page: db.Page, summary: str, content: str, status: str, version: int, author_id: int
-) -> int:
-    """Add a new revision for a page."""
-    # If this doesn't update any rows, there's an edit conflict.
-    # Details: https://gist.github.com/shreevatsa/237bd6592771caadecc68c9515403bc3
-    # FIXME: rather than do this on the application side, do an `exists` query
-    # FIXME: instead? Not sure if this is a clear win, but worth thinking about.
-
-    # FIXME: Check for `proofreading` user permission before allowing changes
-    session = q.get_session()
-    status_ids = {s.name: s.id for s in q.page_statuses()}
-    new_version = version + 1
-    result = session.execute(
-        update(db.Page)
-        .where((db.Page.id == page.id) & (db.Page.version == version))
-        .values(version=new_version, status_id=status_ids[status])
-    )
-    session.commit()
-
-    num_rows_changed = result.rowcount
-    if num_rows_changed == 0:
-        raise EditException("Edit conflict")
-
-    # Must be 1 since there's exactly one page with the given page ID.
-    # If this fails, the application data is in a weird state.
-    assert num_rows_changed == 1
-
-    revision_ = db.Revision(
-        project_id=page.project_id,
-        page_id=page.id,
-        summary=summary,
-        content=content,
-        author_id=author_id,
-        status_id=status_ids[status],
-    )
-    session.add(revision_)
-    session.commit()
-    return new_version
 
 
 @bp.route("/<project_slug>/<page_slug>/")

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -278,17 +278,21 @@ def batch_ocr(slug):
     if project_ is None:
         abort(404)
 
-    running_ocr = False
+    progress = None
     if request.method == "POST":
-        ocr_tasks.run_ocr_for_book.delay(
+        r = ocr_tasks.run_ocr_for_book(
             app_env=current_app.config["AMBUDA_ENVIRONMENT"],
-            project_slug=project_.slug,
-            user_id=current_user.id,
+            project=project_,
+            user=current_user,
         )
-        running_ocr = True
+        num_tasks = len(r.results)
+        if num_tasks:
+            progress = r.completed_count() / len(r.results)
+        else:
+            progress = 0
 
     return render_template(
-        "proofing/projects/batch-ocr.html", project=project_, running_ocr=running_ocr
+        "proofing/projects/batch-ocr.html", project=project_, progress=progress
     )
 
 

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -1,7 +1,6 @@
 from celery.result import GroupResult
 from flask import (
     current_app,
-    jsonify,
     render_template,
     flash,
     url_for,
@@ -22,9 +21,9 @@ from wtforms.widgets import TextArea
 from ambuda import queries as q, database as db
 from ambuda.tasks import ocr as ocr_tasks
 from ambuda.tasks import app as celery_app
-from ambuda.utils.auth import admin_required
 from ambuda.utils import project_utils
 from ambuda.utils import proofing_utils
+from ambuda.utils.auth import admin_required
 
 
 bp = Blueprint("project", __name__)
@@ -285,7 +284,6 @@ def batch_ocr(slug):
         task = ocr_tasks.run_ocr_for_book(
             app_env=current_app.config["AMBUDA_ENVIRONMENT"],
             project=project_,
-            user=current_user,
         )
         if task:
             return render_template(

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -281,7 +281,7 @@ def batch_ocr(slug):
         abort(404)
 
     if request.method == "POST":
-        task = ocr_tasks.run_ocr_for_book(
+        task = ocr_tasks.run_ocr_for_project(
             app_env=current_app.config["AMBUDA_ENVIRONMENT"],
             project=project_,
         )

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -281,8 +281,8 @@ def batch_ocr(slug):
     running_ocr = False
     if request.method == "POST":
         ocr_tasks.run_ocr_for_book.delay(
+            app_env=current_app.config["AMBUDA_ENVIRONMENT"],
             project_slug=project_.slug,
-            app_environment=current_app.config["AMBUDA_ENVIRONMENT"],
             user_id=current_user.id,
         )
         running_ocr = True

--- a/cli.py
+++ b/cli.py
@@ -12,8 +12,8 @@ import ambuda
 from ambuda import database as db
 from ambuda import queries as q
 from ambuda.seed.utils.itihasa_utils import create_db
-from ambuda.tasks.projects import _create_project_inner, LocalTaskStatus
-
+from ambuda.tasks.projects import _create_project_inner
+from ambuda.tasks.utils import LocalTaskStatus
 
 engine = create_db()
 

--- a/config.py
+++ b/config.py
@@ -133,6 +133,10 @@ class BaseConfig:
     # Environment variables
     # ---------------------
 
+    # AMBUDA_BOT_PASSWORD is the password we use for the "ambuda-bot" account.
+    # We set this account as an envvar because we need to create this user as
+    # part of database seeding.
+
     # GOOGLE_APPLICATION_CREDENTIALS contains credentials for the Google Vision
     # API, but these credentials are fetched by the Google API implicitly,
     # so we don't need to define it on the Config object here.

--- a/config.py
+++ b/config.py
@@ -121,10 +121,6 @@ class BaseConfig:
     #: We use Sentry to get notifications about server errors.
     SENTRY_DSN = _env("SENTRY_DSN")
 
-    # We need GOOGLE_APPLICATION_CREDENTIALS for the Google Vision API,
-    # but these credentials are fetched by the Google API implicitly,
-    # so we don't need to define it on the Config object here.
-
     # Test-only
     # ---------
 
@@ -133,6 +129,13 @@ class BaseConfig:
 
     #: If ``True``, enable testing mode.
     TESTING = False
+
+    # Environment variables
+    # ---------------------
+
+    # GOOGLE_APPLICATION_CREDENTIALS contains credentials for the Google Vision
+    # API, but these credentials are fetched by the Google API implicitly,
+    # so we don't need to define it on the Config object here.
 
 
 class UnitTestConfig(BaseConfig):

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -45,6 +45,8 @@ FLASK_UPLOAD_FOLDER="$(pwd)/data/file-uploads"
 SECRET_KEY="insecure development secret key"
 SQLALCHEMY_DATABASE_URI="sqlite:///database.db"
 
+AMBUDA_BOT_PASSWORD="insecure bot password"
+
 GOOGLE_APPLICATION_CREDENTIALS="<Google API credentials>"
 EOF
 

--- a/test/ambuda/tasks/test_projects_tasks.py
+++ b/test/ambuda/tasks/test_projects_tasks.py
@@ -4,6 +4,7 @@ import fitz
 
 import ambuda.queries as q
 import ambuda.tasks.projects as projects
+import ambuda.tasks.utils
 
 
 def _create_sample_pdf(output_path: str, num_pages: int):
@@ -30,7 +31,7 @@ def test_create_project_inner(flask_app):
             output_dir=flask_app.config["UPLOAD_FOLDER"],
             app_environment=flask_app.config["AMBUDA_ENVIRONMENT"],
             creator_id=1,
-            task_status=projects.LocalTaskStatus(),
+            task_status=ambuda.tasks.utils.LocalTaskStatus(),
         )
 
         project = q.project("cool-project")

--- a/test/ambuda/views/proofing/test_page.py
+++ b/test/ambuda/views/proofing/test_page.py
@@ -1,9 +1,10 @@
+import ambuda.utils.assets
 from ambuda.views.proofing import page
 
 
 def test_get_image_filesystem_path(flask_app):
     with flask_app.app_context():
-        path = page._get_image_filesystem_path("project", "1")
+        path = ambuda.utils.assets.get_page_image_filepath("project", "1")
     assert path.match("**/project/pages/1.jpg")
 
 


### PR DESCRIPTION
This lets us run batch OCR by clicking a link in a project's Edit tab.
The UX is poor, and the Celery setup needs more tuning to avoid blocking
PDF uploads. But it's better to ship something usable than wait on
getting every detail right.

Large changes:
- added `ambuda.tasks.ocr` to handle the batch OCR logic.
- added a `create_bot_user` seed script.
- moved some utilities from `tasks/projects.py` to `tasks/utils.py`.
- moved more utilities from `page.py` to `utils/revisions.py`.

Test plan:
- ran OCR for a new project
- ran OCR for a project where OCR has been run already
- existing unit tests

<img width="840" alt="image" src="https://user-images.githubusercontent.com/1429776/188048472-68a452e0-d181-430d-aced-616c8554c743.png">

<img width="518" alt="image" src="https://user-images.githubusercontent.com/1429776/188048573-f7cafa2e-743e-468e-a6dd-cbb4e206cfa2.png">

<img width="539" alt="image" src="https://user-images.githubusercontent.com/1429776/188048672-fe1eeebf-f466-4258-bd1b-c36c810f58a2.png">

<img width="518" alt="image" src="https://user-images.githubusercontent.com/1429776/188048719-70928db2-e18e-45ee-9216-3a6356162a3a.png">

<img width="901" alt="image" src="https://user-images.githubusercontent.com/1429776/188048600-32050d0a-a459-4b1c-ad19-0256de1ec59e.png">

