### PR TITLE
Fix several small issues related to ambuda-bot

### DIFF
--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -319,7 +319,7 @@ def batch_ocr_status(task_id):
             if current == total:
                 status = "SUCCESS"
             else:
-                status == "PROGRESS"
+                status = "PROGRESS"
         else:
             status = "FAILURE"
 

--- a/ambuda/views/proofing/user.py
+++ b/ambuda/views/proofing/user.py
@@ -53,9 +53,13 @@ def activity(username):
     session = q.get_session()
     recent_revisions = (
         session.query(db.Revision)
-        .options(orm.defer(db.Revision.content))
+        .options(
+            orm.defer(db.Revision.content),
+            orm.joinedload(db.Revision.page).load_only(db.Page.id, db.Page.slug),
+        )
         .filter_by(author_id=user_.id)
         .order_by(db.Revision.created.desc())
+        .limit(100)
         .all()
     )
     recent_projects = (

--- a/test/ambuda/conftest.py
+++ b/test/ambuda/conftest.py
@@ -3,7 +3,7 @@ from flask_login import FlaskLoginClient
 
 import ambuda.database as db
 from ambuda import create_app
-from ambuda.consts import TEXT_CATEGORIES
+from ambuda.consts import BOT_USERNAME, TEXT_CATEGORIES
 from ambuda.queries import get_engine, get_session
 
 
@@ -54,6 +54,12 @@ def initialize_test_db():
         dictionary_id=dictionary.id, key="agni", value="<div>fire</div>"
     )
     session.add(dictionary_entry)
+
+    # Bot
+    bot = db.User(username=BOT_USERNAME, email="bot@ambuad.org")
+    bot.set_password("password")
+    session.add(bot)
+    session.flush()
 
     # Auth
     rama = db.User(username="ramacandra", email="rama@ayodhya.com")

--- a/test/ambuda/conftest.py
+++ b/test/ambuda/conftest.py
@@ -56,7 +56,7 @@ def initialize_test_db():
     session.add(dictionary_entry)
 
     # Bot
-    bot = db.User(username=BOT_USERNAME, email="bot@ambuad.org")
+    bot = db.User(username=BOT_USERNAME, email="ambuda-bot@ambuda.org")
     bot.set_password("password")
     session.add(bot)
     session.flush()


### PR DESCRIPTION
1. ambuda-bot's activity floods the "Recent changes" page and makes it
   almost useless. For now, remove all changes by ambuda-bot so that
   contributions by other users are more visible.

2. ambuda-bot has so many contributions in production that its Activity
   page loads very slowly, even with an index. The root cause is an
   unoptimized query. With a small fix, the page should be much more
   performant.

3. ambuda-bot has so many contributions that its Activity page is a
   little overwhelming. For now, show just the 100 most recent revisions
   for a given user.

4. Fix a bug in "Recent changes" where the list of revisions + products
   isn't properly truncated after the sort.

Test plan: tested all of these on the dev server.