### PR TITLE
Fix Unicode encoding

### DIFF
--- a/ambuda/seed/utils/itihasa_utils.py
+++ b/ambuda/seed/utils/itihasa_utils.py
@@ -76,6 +76,7 @@ def fetch_text(url: str) -> str:
     path = CACHE_DIR / code
 
     resp = requests.get(url)
+    resp.encoding = resp.apparent_encoding
     path.write_text(resp.text)
     return resp.text
 

--- a/ambuda/seed/utils/itihasa_utils.py
+++ b/ambuda/seed/utils/itihasa_utils.py
@@ -76,6 +76,10 @@ def fetch_text(url: str) -> str:
     path = CACHE_DIR / code
 
     resp = requests.get(url)
+    # When the response headers don't specify any encoding, `resp.text` decodes
+    # the response as if it is in ISO-8859-1 encoding (following RFC 2616).
+    # This is usually incorrect, so we need to set `resp.encoding` to the 
+    # actual encoding (guessed using `chardet`).
     resp.encoding = resp.apparent_encoding
     path.write_text(resp.text)
     return resp.text


### PR DESCRIPTION
The encoding of the page is UTF-8, even though somehow `requests` thinks that it's ISO-8859-1.

Other alternatives to this fix would be setting `resp.encoding = 'utf-8'` or using `resp.content.decode('utf-8')` instead of `resp.text`.

```
In [1]: import requests

In [2]: resp = requests.get('https://bombay.indology.info/ramayana/text/UD/Ram01.txt')

In [3]: resp.encoding
Out[3]: 'ISO-8859-1'

In [4]: resp.text?
Type:        property
String form: <property object at 0x104e985e0>
Docstring:  
Content of the response, in unicode.

If Response.encoding is None, encoding will be guessed using
``charset_normalizer`` or ``chardet``.

The encoding of the response content is determined based solely on HTTP
headers, following RFC 2616 to the letter. If you can take advantage of
non-HTTP knowledge to make a better guess at the encoding, you should
set ``r.encoding`` appropriately before accessing this property.
```

Tested that `make db-seed-all` works fine with this fix.