### PR TITLE
Hide login controls if not viewing proofing pages

### DIFF
--- a/ambuda/templates/include/header.html
+++ b/ambuda/templates/include/header.html
@@ -1,6 +1,3 @@
-{% if current_user -%}
-{% include 'include/header-login.html' %}
-{%- else %}
 {# https://css-tricks.com/snippets/svg/svg-hamburger-menu/ #}
 {% macro hamburger() %}
 <svg viewBox="0 0 100 80" width="20" height="20">
@@ -25,4 +22,3 @@
     <li><a class="block p-4 py-2" href="{{ url_for('about.index') }}">About</a></li>
   </ul>
 </nav>
-{% endif %}


### PR DESCRIPTION
To a user who just wants to read, login and auth are a distraction.
For such users, just hide these links.

Test plan: unit tests and tested on dev.