### PR TITLE
Fix broken page OCR

### DIFF
--- a/ambuda/utils/google_ocr.py
+++ b/ambuda/utils/google_ocr.py
@@ -7,6 +7,7 @@
 # Billing: https://console.cloud.google.com/billing/
 
 
+import io
 import logging
 from dataclasses import dataclass
 from pathlib import Path

--- a/test/ambuda/utils/test_google_ocr.py
+++ b/test/ambuda/utils/test_google_ocr.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+import tempfile
+
 from ambuda.utils import google_ocr
 
 
@@ -16,6 +19,15 @@ def test_post_process():
 "Hello world"
 'Hello world'"""
     )
+
+
+def test_prepare_image():
+    f = tempfile.NamedTemporaryFile(delete=False)
+    f.write(b"fake image data")
+    f.close()
+
+    res = google_ocr.prepare_image(Path(f.name))
+    assert res.content == b"fake image data"
 
 
 def test_serialize_bounding_boxes():


### PR DESCRIPTION
The `import io` line was removed in https://github.com/ambuda-org/ambuda/pull/317 but wasn't caught in our tests.

Test plan: added a unit test and verified the fix on the dev server.