### PR TITLE
Fix readthedocs.io build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"


### PR DESCRIPTION
The build uses an older Python version by default, which has recently caused the docs to break. Upgrading the Python version we use fixes the issue.

Test plan: created a doc build from this branch.