### PR TITLE
Add various small UX tweaks

### DIFF
--- a/ambuda/templates/header-main-footer.html
+++ b/ambuda/templates/header-main-footer.html
@@ -14,7 +14,9 @@
 {% block body %}
 <body class="flex flex-col">
 {% block header %}
+<div class="text-sky-900 bg-slate-100 border-b mb-4">
 {% include "include/header.html" %}
+</div>
 {% endblock %}
 
 <div class="flex-1">

--- a/ambuda/templates/include/footer.html
+++ b/ambuda/templates/include/footer.html
@@ -9,9 +9,15 @@
   benefit. Learn more about how you can <a href="{{ url_for('site.support') }}">
   help Ambuda grow</a>.</p>
 
+  {% set locales = [
+    ('en', 'English'),
+    ('sa', 'saMskRtam'|d),
+  ] %}
+
   <ul class="my-2 float list-disc ml-4">
-    <li><a href="{{ url_for('site.set_language', language='en') }}">English</a></li>
-    <li><a href="{{ url_for('site.set_language', language='sa') }}">{{ 'saMskRtam'|d }}</a></li>
+    {% for code, text in locales %}
+    <li><a href="{{ url_for('site.set_language', language=code) }}">{{ text }}</a></li>
+    {% endfor %}
   </ul>
 
   <p class="my-2">{{ 'satyaM vada dharmaM cara |'|devanagari }}</p>

--- a/ambuda/templates/include/header.html
+++ b/ambuda/templates/include/header.html
@@ -1,3 +1,4 @@
+{# Header with layout but no color. Apply color in a wrapping parent element. #}
 {# https://css-tricks.com/snippets/svg/svg-hamburger-menu/ #}
 {% macro hamburger() %}
 <svg viewBox="0 0 100 80" width="20" height="20">
@@ -7,8 +8,7 @@
 </svg>
 {% endmacro %}
 
-<nav class="mb-4 border-b md:flex justify-between
-    items-center a-hover-underline text-sky-900 bg-slate-100">
+<nav class="md:flex justify-between items-center a-hover-underline">
   <div class="flex justify-between items-center">
     <a class="p-4 font-bold text-lg" href="{{ url_for('site.index') }}">{{ _('Ambuda') }}</a>
     <div class="block p-4 md:hidden">

--- a/ambuda/templates/index.html
+++ b/ambuda/templates/index.html
@@ -17,37 +17,16 @@
 {% set mobile_only = ["proofing.index", "site.support"] %}
 
 
-{# https://css-tricks.com/snippets/svg/svg-hamburger-menu/ #}
-{% macro hamburger() %}
-<svg fill="#fff" viewBox="0 0 100 80" width="20" height="20">
-  <rect width="100" height="10"></rect>
-  <rect y="30" width="100" height="10"></rect>
-  <rect y="60" width="100" height="10"></rect>
-</svg>
-{% endmacro %}
-
-
 {% block title %}{{ _('Ambuda') }}{% endblock %}
 
 
 {% block header %}
-<header class="text-center bg-brand text-white shrink-0 pb-32">
-  <nav class="mb-4 md:flex justify-between
-      items-center a-hover-underline">
-    <div class="flex justify-between items-center">
-      <a class="p-4 font-bold text-lg" href="{{ url_for('site.index') }}">{{ _('Ambuda') }}</a>
-      <div class="block p-4 md:hidden">
-        <button id="hamburger" type="button">{{ hamburger() }}</button>
-      </div>
-    </div>
-    <ul id="navbar" class="text-slate-300 hidden md:flex hover:text-white">
-      <li><a class="block p-4 py-2" href="{{ url_for('texts.index') }}">{{ _('Texts') }}</a></li>
-      <li><a class="block p-4 py-2" href="{{ url_for('dictionaries.index') }}">{{ _('Dictionaries') }}</a></li>
-      <li><a class="block p-4 py-2" href="{{ url_for('proofing.index') }}">{{ _('Proofing') }}</a></li>
-      <li><a class="block p-4 py-2" href="{{ url_for('about.index') }}">{{ _('About') }}</a></li>
-    </ul>
-  </nav>
+<header class="bg-brand text-white shrink-0 pb-32">
+  <div class="mb-4 fill-white">
+    {% include("include/header.html") %}
+  </div>
 
+  <div class="text-center">
   <div class="max-w-4xl mx-auto mt-28 mb-4 p-4">
     <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold">{{ _('A breakthrough Sanskrit library') }}</h1>
     <p class="mx-auto text-lg mt-4 mb-4 max-w-2xl text-slate-400">Sanskrit
@@ -59,6 +38,7 @@
         hover:bg-white hover:text-brand" href="{{ url_for("texts.index") }}">
         {{ _('Explore the library') }}
     </a>
+  </div>
   </div>
 </header>
 {% endblock %}

--- a/ambuda/templates/texts/index.html
+++ b/ambuda/templates/texts/index.html
@@ -2,7 +2,7 @@
 
 
 {% macro text_list(key, title) %}
-<h2 class="font-bold text-2xl py-2 mt-8 mb-4 border-b">{{ title|devanagari }}</h2>
+<h2 class="font-bold text-2xl py-2 mt-8 mb-4 border-b">{{ title }}</h2>
 
 <ul>
 {% for slug in categories[key] if slug in texts %}
@@ -27,15 +27,11 @@ analysis and integrated dictionary support for a variety of Sanskrit works.
 {% block content %}
 <div class="prose">
   <h1>{{ _('Texts') }}</h1>
-
-  <p>Our main focus right now is on building out the core features of our
-  library. Once those features are in place, we will radically increase the
-  size and quality of our collection.</p>
 </div>
 
-{{ text_list('upanishat', 'upaniSadaH') }}
-{{ text_list('itihasa', 'itihAsAH') }}
-{{ text_list('kavya', 'kAvyAni') }}
-{{ text_list('anye', 'anye granthAH') }}
+{{ text_list('upanishat', _('Upanishads')) }}
+{{ text_list('itihasa', _('Itihasas')) }}
+{{ text_list('kavya', _('Kavyas')) }}
+{{ text_list('anye', _('Other works')) }}
 
 {% endblock %}


### PR DESCRIPTION
- Align menu bar items in `site.index` on mobile.
- Unify `site.index` header with other header logic.
- Define footer language links in a loop.
- Use English text headers in `texts.index`.

Test plan: unit tests.