### PR TITLE
Add support for `/contact` URL

### DIFF
--- a/ambuda/views/site.py
+++ b/ambuda/views/site.py
@@ -10,6 +10,11 @@ def index():
     return render_template("index.html")
 
 
+@bp.route("/contact")
+def contact():
+    return redirect(url_for("about.contact"))
+
+
 @bp.route("/support")
 def support():
     return render_template("support.html")


### PR DESCRIPTION
I accidentally used `/contact` in my emails to potential translators.
But `/contact` raises a 404. Oops!

This is a more intuitive URL anyway, so perhaps we should just
standardize on it.

Test plan: tested on localhost.