### PR TITLE
Allow moderators to delete projects

### DIFF
--- a/ambuda/tasks/projects.py
+++ b/ambuda/tasks/projects.py
@@ -70,7 +70,7 @@ def _add_project_to_database(title: str, slug: str, num_pages: int, creator_id: 
     session.commit()
 
 
-def _create_project_inner(
+def create_project_inner(
     *,
     title: str,
     pdf_path: str,
@@ -132,10 +132,10 @@ def create_project(
 ):
     """Split the given PDF into pages and register the project on the database.
 
-    For argument details, see `_create_project_inner`.
+    For argument details, see `create_project_inner`.
     """
     task_status = CeleryTaskStatus(self)
-    _create_project_inner(
+    create_project_inner(
         title=title,
         pdf_path=pdf_path,
         output_dir=output_dir,

--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -52,7 +52,7 @@
 
 
 {# Project-level tabs. #}
-{% macro project_nav(project, active, is_admin = false) %}
+{% macro project_nav(project, active, is_mod = false) %}
 {% set routes = [
   ("summary",  _("Summary"),   url_for("proofing.project.summary", slug=project.slug)),
   ("activity", _("Activity"),  url_for("proofing.project.activity", slug=project.slug)),
@@ -60,7 +60,7 @@
   ("edit",     _("Edit"),      url_for("proofing.project.edit", slug=project.slug)),
   ("download", _("Download"),  url_for("proofing.project.download", slug=project.slug)),
 ] %}
-{% if is_admin %}{% set routes = routes + [
+{% if is_mod %}{% set routes = routes + [
   ("admin",    _("Admin"),     url_for("proofing.project.admin", slug=project.slug)),
 ] %}{% endif %}
 

--- a/ambuda/templates/proofing/projects/activity.html
+++ b/ambuda/templates/proofing/projects/activity.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ m.project_header_nested('Activity', project) }}
-{{ m.project_nav(project=project, active='activity', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='activity', is_mod=current_user.is_moderator) }}
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
 
 {{ m.activity_log(recent_activity) }}

--- a/ambuda/templates/proofing/projects/admin.html
+++ b/ambuda/templates/proofing/projects/admin.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ m.project_header_nested("Admin", project) }}
-{{ m.project_nav(project=project, active='admin', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='admin', is_mod=current_user.is_moderator) }}
 
 <div class="prose">
 

--- a/ambuda/templates/proofing/projects/batch-ocr-post.html
+++ b/ambuda/templates/proofing/projects/batch-ocr-post.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 {{ m.project_header_nested('OCR', project) }}
-{{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
 
 {% set url = url_for('proofing.project.batch_ocr_status', task_id=task_id) %}
 <div id="progress" x-data="htmlPoller('{{ url }}')">

--- a/ambuda/templates/proofing/projects/batch-ocr.html
+++ b/ambuda/templates/proofing/projects/batch-ocr.html
@@ -11,7 +11,7 @@
 {{ components.flash_messages() }}
 
 {{ m.project_header_nested('OCR', project) }}
-{{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
 
 <div class="prose">
   <p>Click the button below to run OCR on every unedited page.</p>

--- a/ambuda/templates/proofing/projects/download.html
+++ b/ambuda/templates/proofing/projects/download.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 {{ m.project_header_nested('Download', project) }}
-{{ m.project_nav(project=project, active='download', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='download', is_mod=current_user.is_moderator) }}
 
 <div class="prose">
   <p>{% trans %}

--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -12,7 +12,8 @@
 
 {% block content %}
 {{ m.project_header_nested('Edit', project) }}
-{{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
+
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
 {% set ocr_url = url_for("proofing.project.batch_ocr", slug=project.slug)  %}
 

--- a/ambuda/templates/proofing/projects/search.html
+++ b/ambuda/templates/proofing/projects/search.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 {{ m.project_header_nested('Search', project) }}
-{{ m.project_nav(project=project, active='edit', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
 
 <div class="prose">
   <p>Use this simple search form to find typos across this project.</p>

--- a/ambuda/templates/proofing/projects/summary.html
+++ b/ambuda/templates/proofing/projects/summary.html
@@ -14,7 +14,7 @@
 {{ components.flash_messages() }}
 
 <h1 class="font-bold text-3xl mb-4">{{ project.title }}</h1>
-{{ m.project_nav(project=project, active='summary', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='summary', is_mod=current_user.is_moderator) }}
 
 {% if project.description %}
 <div class="prose">

--- a/ambuda/templates/proofing/talk/board.html
+++ b/ambuda/templates/proofing/talk/board.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ m.project_header_nested('Talk', project) }}
-{{ m.project_nav(project=project, active='talk', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='talk', is_mod=current_user.is_moderator) }}
 
 <div class="my-4">
 <a class="btn btn-basic" href="{{ url_for('proofing.talk.create_thread', slug=project.slug) }}">

--- a/ambuda/templates/proofing/talk/thread.html
+++ b/ambuda/templates/proofing/talk/thread.html
@@ -39,7 +39,7 @@
 
 {% block content %}
 {{ m.project_header_nested("Talk", project) }}
-{{ m.project_nav(project=project, active='talk', is_admin=current_user.is_admin) }}
+{{ m.project_nav(project=project, active='talk', is_mod=current_user.is_moderator) }}
 
 <header class="flex justify-between items-center bg-slate-100 p-4">
   <h1 class="text-xl font-bold">{{ thread.title }}</h1>

--- a/ambuda/views/proofing/project.py
+++ b/ambuda/views/proofing/project.py
@@ -24,8 +24,7 @@ from ambuda import queries as q
 from ambuda.tasks import app as celery_app
 from ambuda.tasks import ocr as ocr_tasks
 from ambuda.utils import project_utils, proofing_utils
-from ambuda.utils.auth import admin_required
-from ambuda.views.proofing.decorators import p2_required
+from ambuda.views.proofing.decorators import moderator_required, p2_required
 
 bp = Blueprint("project", __name__)
 
@@ -351,7 +350,7 @@ def batch_ocr_status(task_id):
 
 
 @bp.route("/<slug>/admin", methods=["GET", "POST"])
-@admin_required
+@moderator_required
 def admin(slug):
     """View admin controls for the project.
 

--- a/cli.py
+++ b/cli.py
@@ -12,7 +12,7 @@ import ambuda
 from ambuda import database as db
 from ambuda import queries as q
 from ambuda.seed.utils.itihasa_utils import create_db
-from ambuda.tasks.projects import _create_project_inner
+from ambuda.tasks.projects import create_project_inner
 from ambuda.tasks.utils import LocalTaskStatus
 
 engine = create_db()
@@ -97,7 +97,7 @@ def create_project(title, pdf_path):
             Path(current_app.config["UPLOAD_FOLDER"]) / "projects" / slug / "pages"
         )
         page_image_dir.mkdir(parents=True, exist_ok=True)
-        _create_project_inner(
+        create_project_inner(
             title=title,
             pdf_path=pdf_path,
             output_dir=str(page_image_dir),

--- a/cli.py
+++ b/cli.py
@@ -12,7 +12,8 @@ import ambuda
 from ambuda import database as db
 from ambuda import queries as q
 from ambuda.seed.utils.itihasa_utils import create_db
-from ambuda.tasks.projects import LocalTaskStatus, _create_project_inner
+from ambuda.tasks.projects import _create_project_inner
+from ambuda.tasks.utils import LocalTaskStatus
 
 engine = create_db()
 

--- a/test/ambuda/conftest.py
+++ b/test/ambuda/conftest.py
@@ -67,6 +67,12 @@ def initialize_test_db():
     session.add(rama)
     session.flush()
 
+    # Moderator
+    moderator = db.User(username="user-mod", email="mod@ambuda.org")
+    moderator.set_password("secret password")
+    session.add(moderator)
+    session.flush()
+
     # Admin
     admin = db.User(username="akprasad", email="arun@ambuda.org")
     admin.set_password("secret password")
@@ -76,15 +82,19 @@ def initialize_test_db():
     # Roles
     p1_role = db.Role(name=db.SiteRole.P1.value)
     p2_role = db.Role(name=db.SiteRole.P2.value)
+    moderator_role = db.Role(name=db.SiteRole.MODERATOR.value)
     admin_role = db.Role(name=db.SiteRole.ADMIN.value)
     session.add(p1_role)
     session.add(p2_role)
+    session.add(moderator_role)
     session.add(admin_role)
     session.flush()
 
     rama.roles = [p1_role, p2_role]
+    moderator.roles = [p1_role, p2_role, moderator_role]
     admin.roles = [p1_role, p2_role, admin_role]
     session.add(rama)
+    session.add(moderator)
     session.add(admin)
     session.flush()
 
@@ -145,6 +155,13 @@ def rama_client(flask_app):
     session = get_session()
     user = session.query(db.User).filter_by(username="ramacandra").first()
     return flask_app.test_client(user=user)
+
+
+@pytest.fixture()
+def moderator_client(flask_app):
+    session = get_session()
+    moderator = session.query(db.User).filter_by(username="user-mod").first()
+    return flask_app.test_client(user=moderator)
 
 
 @pytest.fixture()

--- a/test/ambuda/tasks/test_projects_tasks.py
+++ b/test/ambuda/tasks/test_projects_tasks.py
@@ -25,7 +25,7 @@ def test_create_project_inner(flask_app):
         f = tempfile.NamedTemporaryFile()
         _create_sample_pdf(f.name, num_pages=10)
 
-        projects._create_project_inner(
+        projects.create_project_inner(
             title="Cool project",
             pdf_path=f.name,
             output_dir=flask_app.config["UPLOAD_FOLDER"],

--- a/test/ambuda/views/proofing/test_project.py
+++ b/test/ambuda/views/proofing/test_project.py
@@ -115,12 +115,18 @@ def test_admin__no_admin(rama_client):
     assert resp.status_code == 302
 
 
-def test_admin__has_admin(admin_client):
+def test_admin__has_moderator_role(moderator_client):
+    resp = moderator_client.get("/proofing/test-project/admin")
+    assert resp.status_code == 200
+    assert "Admin:" in resp.text
+
+
+def test_admin__has_admin_role(admin_client):
     resp = admin_client.get("/proofing/test-project/admin")
     assert resp.status_code == 200
     assert "Admin:" in resp.text
 
 
-def test_admin__has_admin__bad_project(admin_client):
+def test_admin__has_moderator_role__bad_project(admin_client):
     resp = admin_client.get("/proofing/unknown/admin")
     assert resp.status_code == 404


### PR DESCRIPTION
This extends our project admin panel to moderators. Currently, we do
hard deletes, but we can implement soft deletes in the future.

Test plan: tested this functionality on dev.