### PR TITLE
Genericize admin username in tests

### DIFF
--- a/test/ambuda/conftest.py
+++ b/test/ambuda/conftest.py
@@ -68,7 +68,7 @@ def initialize_test_db():
     session.flush()
 
     # Admin
-    admin = db.User(username="akprasad", email="arun@ambuda.org")
+    admin = db.User(username="u-admin", email="admin@ambuda.org")
     admin.set_password("secret password")
     session.add(admin)
     session.flush()
@@ -150,5 +150,5 @@ def rama_client(flask_app):
 @pytest.fixture()
 def admin_client(flask_app):
     session = get_session()
-    user = session.query(db.User).filter_by(username="akprasad").first()
+    user = session.query(db.User).filter_by(username="u-admin").first()
     return flask_app.test_client(user=user)

--- a/test/ambuda/views/proofing/test_user.py
+++ b/test/ambuda/views/proofing/test_user.py
@@ -1,5 +1,5 @@
 def test_summary(client):
-    resp = client.get("/proofing/users/akprasad/")
+    resp = client.get("/proofing/users/u-admin/")
     assert resp.status_code == 200
 
 
@@ -24,7 +24,7 @@ def test_edit__user_match__post(rama_client):
 
 
 def test_edit__user_mismatch(rama_client):
-    resp = rama_client.get("/proofing/users/akprasad/edit")
+    resp = rama_client.get("/proofing/users/u-admin/edit")
     assert resp.status_code == 403
 
 
@@ -44,7 +44,7 @@ def test_summary__missing(client):
 
 
 def test_activity(client):
-    resp = client.get("/proofing/users/akprasad/activity")
+    resp = client.get("/proofing/users/u-admin/activity")
     assert resp.status_code == 200
 
 
@@ -54,12 +54,12 @@ def test_activity__missing(client):
 
 
 def test_admin(admin_client):
-    resp = admin_client.get("/proofing/users/akprasad/admin")
+    resp = admin_client.get("/proofing/users/u-admin/admin")
     assert resp.status_code == 200
 
 
 def test_admin__unauth(rama_client):
-    resp = rama_client.get("/proofing/users/akprasad/admin")
+    resp = rama_client.get("/proofing/users/u-admin/admin")
     assert resp.status_code == 302
 
 

--- a/test/ambuda/views/test_auth.py
+++ b/test/ambuda/views/test_auth.py
@@ -136,18 +136,18 @@ def test_get_reset_password_token__get(client):
 
 def test_reset_password_from_token(client):
     with client:
-        user = q.user("akprasad")
+        user = q.user("u-admin")
 
     user_id = user.id
     raw_token = auth._create_reset_token(user_id)
 
-    r = client.get("/reset-password/akprasad/bad_token")
+    r = client.get("/reset-password/u-admin/bad_token")
     assert r.status_code == 302
 
     r = client.get(f"/reset-password/bad-user/{raw_token}")
     assert r.status_code == 302
 
-    r = client.get(f"/reset-password/akprasad/{raw_token}")
+    r = client.get(f"/reset-password/u-admin/{raw_token}")
     assert "Change password for" in r.text
 
 


### PR DESCRIPTION
I used my own username as a placeholder when writing these tests, but I don't like the message this sends to contributors, as Ambuda is bigger than any one person.

I use `u-admin` as a placeholder to make this user's role clear, and I avoided variants like `admin-user` to avoid confusion with the `user` and `users` strings that appear in other contexts.

Test plan: unit tests pass.