### PR TITLE
Add Markdown filter for blog posts

### DIFF
--- a/ambuda/templates/blog/base.html
+++ b/ambuda/templates/blog/base.html
@@ -6,11 +6,6 @@ Follow along with the latest updates on Ambuda.
 {%- endblock %}
 
 
-{% block header %}
-{% include "include/header-login.html" %}
-{% endblock %}
-
-
 {% block main %}
   <article class="p-4 xl:p-0 max-w-4xl mx-auto mb-24">
   {% block content %}{% endblock %}

--- a/ambuda/templates/blog/create-post.html
+++ b/ambuda/templates/blog/create-post.html
@@ -1,5 +1,10 @@
 {% extends 'blog/base.html' %}
+{% import "macros/components.html" as mc %}
 {% import 'macros/forms.html' as mf %}
+
+
+{% block title %}{{ mc.title('Create blog post') }}{% endblock %}
+
 
 {% block content %}
 <div class="prose">

--- a/ambuda/templates/blog/delete-post.html
+++ b/ambuda/templates/blog/delete-post.html
@@ -1,18 +1,22 @@
 {% extends 'blog/base.html' %}
+{% import "macros/components.html" as mc %}
 {% import 'macros/forms.html' as mf %}
+
+
+{% block title %}{{ mc.title('Delete post: {}'.format(post.title)) }}{% endblock %}
+
 
 {% block content %}
 <div class="prose">
   <h1>Delete post: "{{ post.title }}"</h1>
 </div>
 
+{{ mf.show_errors_if_any(form.errors) }}
 <form method="POST" class="border border-red-500 rounded p-4 my-4">
-
 {{ form.csrf_token }}
 
 <p>To confirm this decision, enter <kbd>{{ post.slug }}</kbd> in the field below.</p>
 {{ form.slug(class_="p-2 block w-full my-4 border") }}
-
 
 <div class="mt-4">
   <input class="btn btn-submit" type="submit" value="Delete post">

--- a/ambuda/templates/blog/edit-post.html
+++ b/ambuda/templates/blog/edit-post.html
@@ -1,5 +1,10 @@
 {% extends 'blog/base.html' %}
+{% import 'macros/components.html' as mc %}
 {% import 'macros/forms.html' as mf %}
+
+
+{% block title %}{{ mc.title('Edit post: {}'.format(post.title)) }}{% endblock %}
+
 
 {% block content %}
 <div class="prose">

--- a/ambuda/templates/blog/index.html
+++ b/ambuda/templates/blog/index.html
@@ -13,7 +13,7 @@
 
 {{ m.flash_messages() }}
 
-<header class="text-center my-8">
+<header class="text-center mt-20 mb-8 text-slate-600">
   <h1 class="font-bold text-4xl mb-4">{{ _('Ambuda blog') }}</h1>
   <p class="a-underline">{% trans %}
   Follow our blog for project updates, volunteer opportunities, and other news
@@ -33,7 +33,7 @@
 {% for post in posts %}
 <section class="border-t border-slate-300 py-8">
   <header class="mb-2">
-    <h1 class="font-bold text-2xl">
+    <h1 class="font-bold text-3xl">
       <a class="hover:underline" href="{{ url_for('blog.post', slug=post.slug) }}">
         {{ post.title }}
       </a>
@@ -42,7 +42,7 @@
   </header>
 
   <div class="prose">
-    {{ post.content }}
+    {{ post.content|markdown|safe }}
   </div>
 </section>
 {% endfor %}

--- a/ambuda/templates/blog/post.html
+++ b/ambuda/templates/blog/post.html
@@ -1,25 +1,29 @@
 {% extends 'blog/base.html' %}
+{% import "macros/components.html" as m %}
+
+
+{% block title %}{{ m.title(post.title) }}{% endblock %}
 
 
 {% block content %}
 <div class="max-w-xl mx-auto mt-24">
 
-  <a class="block uppercase font-bold text-slate-500"
+  <a class="block text-sm uppercase font-bold text-slate-400"
     href="{{ url_for('blog.index') }}">&larr; All posts</a>
 
   <header class="mt-4 mb-8">
-    <h1 class="font-bold text-4xl">{{ post.title }}</h1>
+    <h1 class="font-bold text-5xl mb-2">{{ post.title }}</h1>
     <p class="text-slate-500">
       Created {{ post.created_at|time_ago }}
       {% if current_user.is_moderator %}
-      | <a href="{{ url_for('blog.edit_post', slug=post.slug) }}">Edit</a>
-      | <a href="{{ url_for('blog.delete_post', slug=post.slug) }}">Delete</a>
+      &middot; <a href="{{ url_for('blog.edit_post', slug=post.slug) }}">Edit</a>
+      &middot; <a href="{{ url_for('blog.delete_post', slug=post.slug) }}">Delete</a>
       {% endif %}
     </p>
   </header>
 
   <div class="prose">
-    {{ post.content }}
+    {{ post.content|markdown|safe }}
   </div>
 
 </div>

--- a/ambuda/views/blog.py
+++ b/ambuda/views/blog.py
@@ -3,9 +3,13 @@
 The blog is a work in progress and doesn't have a defined voice, level of
 formality, etc. For now, we use it for any text content that it doesn't make
 sense to check into version control.
+
+Notes on i18n: Generally, this interface is for admins and moderators, so the
+`gettext` annotations here are quite lax.
 """
 
 from flask import Blueprint, abort, flash, redirect, render_template, url_for
+from flask_babel import lazy_gettext as _l
 from flask_login import current_user
 from flask_wtf import FlaskForm
 from slugify import slugify
@@ -72,7 +76,7 @@ def create_post():
         session.add(post)
         session.commit()
 
-        flash("Created post.")
+        flash(_l("Created post."), "success")
         return redirect(url_for("blog.index"))
 
     return render_template("blog/create-post.html", form=form)
@@ -92,7 +96,7 @@ def edit_post(slug):
         form.populate_obj(post_)
         session.commit()
 
-        flash("Edited post.")
+        flash(_l("Edited post."), "success")
         return redirect(url_for("blog.index"))
 
     return render_template("blog/edit-post.html", post=post_, form=form)
@@ -113,7 +117,7 @@ def delete_post(slug):
             session.delete(post_)
             session.commit()
 
-            flash(f"Deleted post {slug}")
+            flash(f"Deleted post {slug}", "success")
             return redirect(url_for("blog.index"))
         else:
             form.slug.errors.append("Mismatch with project slug.")


### PR DESCRIPTION
This amends the previous commit to add Markdown parsing. Along the way, fix various small UI problems:

- Make `flash` success messages green.
- Add missing page titles.
- Tweak heading CSS.

Test plan: unit tests and experimented on dev.