### PR TITLE
Fix DB upgrade in deploy script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ install-python:
 # Upgrade an existing setup.
 upgrade:
 	make install-frontend install-python
-	. env/bin/activate; python -m ambuda.seed.lookup
 	. env/bin/activate; alembic upgrade head
+	. env/bin/activate; python -m ambuda.seed.lookup
 
 # Seed the database with just enough data for the devserver to be interesting.
 db-seed-basic: py-venv-check

--- a/migrations/versions/99379162619e_add_user_statuses.py
+++ b/migrations/versions/99379162619e_add_user_statuses.py
@@ -11,7 +11,7 @@ from sqlalchemy import orm
 
 # revision identifiers, used by Alembic.
 revision = "99379162619e"
-down_revision = "bc48af5ec2e6"
+down_revision = "f7e0e62a5cfa"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
- Upgrade schemas before trying to seed. Otherwise, a schema change causes the seed scripts to fail.
- Fix the down revision in the latest migration so that migration history is linear.