### PR TITLE
Fix bug: single-section texts show "all" in nav

### DIFF
--- a/ambuda/consts.py
+++ b/ambuda/consts.py
@@ -1,13 +1,40 @@
+"""Various constants.
+
+This module is for constants that we use across the application. Constants that
+are more locally scoped should be defined in the modules that use them.
+"""
+
 from dataclasses import dataclass
 
 
 @dataclass
 class Locale:
+    """Represents a locale option that we expose to users.
+
+    Requirements:
+    - `code` must correspond to a language listed in our Transifex project [1].
+    - Translation data should cover, at a minimum, all of the core UI text on
+      Ambuda.
+
+    [1]: https://www.transifex.com/ambuda/ambuda
+    """
+
+    #: The full locale for this code, e.g. "hi_IN"
     code: str
+    #: The locale as it appears in the URL, e.g. "hi". This is just a
+    #: simpliifed version of `code`. We use `slug` over `code` for a simpler
+    #: user experience.
     slug: str
+    #: The human-readable name of this language. We follow the convention of
+    #: sites like Wikipedia and use a name that a native speaker of the
+    #: language would use and prefer, thus "Italiano" and not "Italian."
     text: str
 
 
+#: Defines a rough taxonomy of texts.
+#:
+#: This taxonomy is a temporary measure, and soon we will move this data into
+#: the database and avoid hard-coding a lists of texts.
 TEXT_CATEGORIES = {
     "itihasa": [
         "ramayanam",
@@ -36,9 +63,19 @@ TEXT_CATEGORIES = {
 }
 
 
+#: The username for our internal bot user.
+
+#: `ambuda-bot` performs background tasks like OCR. We assign these tasks to a
+#: bot user so that we can better separate automatic work from work done
+#: manually.
 BOT_USERNAME = "ambuda-bot"
 
 
+#: All of the locales we support on Ambuda.
+#:
+#: We render this list of locales on the main page and in page footers. As this
+#: list grows, we can consider more manageable ways to present this data to the
+#: user.
 LOCALES = [
     Locale(code="sa", slug="sa", text="संस्कृतम्"),
     Locale(code="en", slug="en", text="English"),

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -90,7 +90,9 @@ or in their own modal window. #}
     <a class="hover:underline" href="{{ url_for('texts.text', slug=text.slug) }}">
       {{ text.title | devanagari }}
     </a>
-    {{ section.title | devanagari }}
+    {% if not is_single_section_text %}
+      {{ section.title | devanagari }}
+    {% endif %}
   </div>
   <div class="flex items-center">
     {{ settings() }}


### PR DESCRIPTION
A *single-section* text is a text with no major divisions -- no kaandas, no sargas, etc. Internally, we represent such texts as texts with a single section with the slug `"all"`.

Our current reader UI displays this `"all"` slug as if it's a valid identifier, which is unsightly. So as a fix, show the section slug only if the text has multiple sections.

Test plan: clicked around on dev

Before:

<img width="138" alt="image" src="https://user-images.githubusercontent.com/1429776/192121742-305571ce-55c1-4437-ac57-3c3dce0bd3ca.png">

After:

<img width="109" alt="image" src="https://user-images.githubusercontent.com/1429776/192121749-f230187c-aaf0-4042-b07d-dc593023a702.png">
