### PR TITLE
Update dictionary state using URL data

### DIFF
--- a/ambuda/static/js/dictionary.js
+++ b/ambuda/static/js/dictionary.js
@@ -18,8 +18,16 @@ export default () => ({
   query: '',
 
   init() {
+    // URL settings take priority.
+    this.parseURL();
     this.loadSettings();
     this.transliterate('devanagari', this.script);
+  },
+
+  parseURL() {
+    const { query, source } = Routes.parseDictionaryURL();
+    this.query = query || this.query;
+    this.source = source || this.source;
   },
 
   loadSettings() {
@@ -44,8 +52,7 @@ export default () => ({
     localStorage.setItem(DICTIONARY_CONFIG_KEY, JSON.stringify(settings));
   },
 
-  async setSource(value) {
-    this.source = value;
+  async updateSource() {
     this.saveSettings();
     // Return the promise so we can await it in tests.
     return this.searchDictionary(this.query);

--- a/ambuda/static/js/dictionary.js
+++ b/ambuda/static/js/dictionary.js
@@ -19,12 +19,13 @@ export default () => ({
 
   init() {
     // URL settings take priority.
-    this.parseURL();
+    this.loadSettingsFromURL();
     this.loadSettings();
     this.transliterate('devanagari', this.script);
   },
 
-  parseURL() {
+  /** Load source and query from the URL (if defined). */
+  loadSettingsFromURL() {
     const { query, source } = Routes.parseDictionaryURL();
     this.query = query || this.query;
     this.source = source || this.source;
@@ -44,6 +45,7 @@ export default () => ({
       }
     }
   },
+
   saveSettings() {
     const settings = {
       script: this.script,
@@ -57,6 +59,7 @@ export default () => ({
     // Return the promise so we can await it in tests.
     return this.searchDictionary(this.query);
   },
+
   updateScript() {
     this.transliterate(this.script, this.uiScript);
     this.script = this.uiScript;
@@ -81,6 +84,7 @@ export default () => ({
       $container.innerHTML = '<p>Sorry, this content is not available right now.</p>';
     }
   },
+
   transliterate(oldScript, newScript) {
     transliterateElement($('#dict--response'), oldScript, newScript);
   },

--- a/ambuda/static/js/routes.js
+++ b/ambuda/static/js/routes.js
@@ -10,4 +10,22 @@ export default {
     const slug = suffix.split('/')[0];
     return slug;
   },
+
+  parseDictionaryURL: () => {
+    const { pathname } = window.location;
+
+    const prefix = '/tools/dictionaries/';
+    const segments = pathname.split('/');
+    // segments: "", "tools", "dictionaries", "<source>", "<query>"
+    if (pathname.startsWith(prefix) && segments.length === 5) {
+      return {
+        source: segments[3],
+        query: segments[4],
+      };
+    }
+    return {
+      source: null,
+      query: null,
+    };
+  },
 };

--- a/ambuda/static/js/routes.js
+++ b/ambuda/static/js/routes.js
@@ -11,6 +11,10 @@ export default {
     return slug;
   },
 
+  /**
+   * Parse a dictionary URL for its source and query. We use this data to
+   * initialize our form fields from the URL state.
+   */
   parseDictionaryURL: () => {
     const { pathname } = window.location;
 

--- a/ambuda/templates/dictionaries/index.html
+++ b/ambuda/templates/dictionaries/index.html
@@ -37,7 +37,8 @@ different languages.
       name="version"
       class="text-sm bg-zinc-100
       text-zinc-400 hover:text-zinc-800 p-1"
-      @change="setSource($event.target.value)">
+      x-model="source"
+      @change="updateSource">
     {% include "include/dict-options.html" %}
   </select>
   <select

--- a/test/js/dictionary.test.js
+++ b/test/js/dictionary.test.js
@@ -69,13 +69,14 @@ test('loadSettings works if localStorage data is corrupt', () => {
   expect(d.source).toBe('mw');
 });
 
-test('setSource sets dictionary source then fetches', async () => {
+test('updateSource updates config then fetches', async () => {
   const d = Dictionary();
   d.init();
   d.query = 'foo';
   expect(d.source).toBe('mw');
 
-  await d.setSource('apte');
+  d.source = 'apte';
+  await d.updateSource();
   expect(d.source).toBe('apte');
   expect($('#dict--response').innerHTML).toBe('<div>fetched apte:foo</div>');
 });

--- a/test/js/routes.test.js
+++ b/test/js/routes.test.js
@@ -1,5 +1,13 @@
 import Routes from '@/routes';
 
+beforeEach() {
+  // I was not able to redefine the property after the first definition.
+  // Instead, define it once then use simple assignment in each test.
+  Object.defineProperty(window, 'location', {
+    value: { pathname: '' },
+  });
+}
+
 test('ajaxDictionaryQuery', () => {
   expect(Routes.ajaxDictionaryQuery('mw', 'nara')).toBe('/api/dictionaries/mw/nara');
 });
@@ -13,10 +21,16 @@ test('parseData', () => {
 });
 
 test('getTextSlug', () => {
-  Object.defineProperty(window, 'location', {
-    value: {
-      pathname: '/texts/ramayana/1.1',
-    },
-  });
+  window.location.pathname = '/texts/ramayana/1.1';
   expect(Routes.getTextSlug()).toBe('ramayana');
+});
+
+test('parseDictionaryURL returns fields with valid URL', () => {
+  window.location.pathname = '/tools/dictionaries/apte/deva',
+  expect(Routes.parseDictionaryURL()).toEqual({ source: "apte", query: "deva" });
+});
+
+test('parseDictionaryURL returns nulls with invalid URL', () => {
+  window.location.pathname = '/tools/dictionaries/',
+  expect(Routes.parseDictionaryURL()).toEqual({ source: null, query: null });
 });

--- a/test/js/routes.test.js
+++ b/test/js/routes.test.js
@@ -1,12 +1,12 @@
 import Routes from '@/routes';
 
-beforeEach() {
+beforeEach(() => {
   // I was not able to redefine the property after the first definition.
   // Instead, define it once then use simple assignment in each test.
   Object.defineProperty(window, 'location', {
     value: { pathname: '' },
   });
-}
+});
 
 test('ajaxDictionaryQuery', () => {
   expect(Routes.ajaxDictionaryQuery('mw', 'nara')).toBe('/api/dictionaries/mw/nara');


### PR DESCRIPTION
If the dictionary URL ends with "/apte/deva", update the dictionary app so that its dictionary menu shows `apte` and its query field shows `deva`.

Test plan: unit tests and ran on dev.