### PR TITLE
[proofing] Add filter field for project list

### DIFF
--- a/ambuda/static/js/sortable-list.js
+++ b/ambuda/static/js/sortable-list.js
@@ -6,12 +6,48 @@ function sortDescending(field) {
   return (a, b) => (a.dataset[field] < b.dataset[field] ? 1 : -1);
 }
 
+/**
+ * A simple sortable table.
+ *
+ * FIXME: this class is a kludge of data in markup (through data- attributes)
+ * and data in JS (through `this.data`). If we need to add more features here,
+ * clean it up properly first.
+ */
 export default (defaultField) => ({
-  // The sort field. Initialize this in `x-init`.
+  // The sort field. Initialize this in `x-data`.
   field: defaultField,
-  // The order ("asc" or "desc"). Initialize this in `x-init`.
+  // The query to filter by. If empty, use all data.
+  query: '',
+  // The order of the sort ("asc" or "desc").
   order: 'asc',
+  // The keys to display.
+  displayed: new Set(),
+  // A simplified representation of the project data.
+  data: [],
 
+  init() {
+    const { list } = this.$refs;
+    this.data = [...list.children].map((x) => ({
+      key: x.dataset.key,
+      // Store title in lowercase to support case-insensitive searching
+      title: x.dataset.title.toLowerCase(),
+    }));
+    // Collect all keys in `this.displayed`.
+    this.displayed = new Set([...list.children].map((x) => x.dataset.key));
+  },
+
+  /** Filter the list by the user's query string. */
+  filter() {
+    if (!this.query) {
+      return;
+    }
+    // toLowerCase for case-insensitive matching.
+    const query = this.query.toLowerCase();
+    const newKeys = this.data.filter((x) => x.title.includes(query)).map((x) => x.key);
+    this.displayed = new Set(newKeys);
+  },
+
+  /** Sort the filtered list by field `this.field` in order `this.order`. */
   sort() {
     const orderFn = this.order === 'asc' ? sortAscending : sortDescending;
     const { list } = this.$refs;

--- a/ambuda/static/js/sortable-list.js
+++ b/ambuda/static/js/sortable-list.js
@@ -38,12 +38,15 @@ export default (defaultField) => ({
 
   /** Filter the list by the user's query string. */
   filter() {
-    if (!this.query) {
-      return;
+    let newKeys = null;
+    if (this.query) {
+      const query = this.query.toLowerCase();
+      // toLowerCase for case-insensitive matching.
+      newKeys = this.data.filter((x) => x.title.includes(query)).map((x) => x.key);
+    } else {
+      newKeys = this.data.map((x) => x.key);
     }
-    // toLowerCase for case-insensitive matching.
-    const query = this.query.toLowerCase();
-    const newKeys = this.data.filter((x) => x.title.includes(query)).map((x) => x.key);
+
     this.displayed = new Set(newKeys);
   },
 

--- a/ambuda/templates/proofing/index.html
+++ b/ambuda/templates/proofing/index.html
@@ -34,7 +34,8 @@
 
 <div x-data="sortableList('title')">
 
-<form x-cloak class="border p-2 bg-slate-100 rounded text-sm flex items-center">
+<form class="border p-2 bg-slate-100 rounded text-sm flex items-center"
+    x-cloak @submit.prevent>
   <input type="text" placeholder="Search for a project title" x-model="query"
      class="p-1 rounded border flex-1 mr-4" @keyup="filter"></input>
   <label class="text-slate-500 mr-2">{{ _('Sort by:') }}</label>

--- a/ambuda/templates/proofing/index.html
+++ b/ambuda/templates/proofing/index.html
@@ -34,14 +34,16 @@
 
 <div x-data="sortableList('title')">
 
-<form class="border p-2 rounded text-sm">
-  <label class="text-slate-500">{{ _('Sort by:') }}</label>
-  <select class="bg-white" x-model="field" @change="sort">
+<form x-cloak class="border p-2 bg-slate-100 rounded text-sm flex items-center">
+  <input type="text" placeholder="Search for a project title" x-model="query"
+     class="p-1 rounded border flex-1 mr-4" @keyup="filter"></input>
+  <label class="text-slate-500 mr-2">{{ _('Sort by:') }}</label>
+  <select class="bg-white mr-2 p-1" x-model="field" @change="sort">
     <option value="title" selected>{{ _('Title') }}</option> 
     <option value="created">{{ _('Creation date') }}</option> 
     <option value="progress">{{ _('Progress') }}</option> 
   </select>
-  <select class="bg-white" x-model="order" @change="sort">
+  <select class="bg-white p-1" x-model="order" @change="sort">
     <option value="asc" selected>{{ _('Ascending') }}</option> 
     <option value="desc">{{ _('Descending') }}</option> 
   </select>
@@ -49,9 +51,11 @@
 
 <ul x-ref="list">
   {% for p in projects %}
-  <li data-title="{{ p.title }}"
+  <li data-key="{{ p.id }}"
+      data-title="{{ p.title }}"
       data-created="{{ p.created_at }}"
-      data-progress="{{ progress_per_project[p.id] }}">
+      data-progress="{{ progress_per_project[p.id] }}"
+      x-show="displayed.has('{{ p.id }}')">
     <div class="mt-4 a-hover-underline flex justify-between items-baseline">
       <a href="{{ url_for("proofing.project.summary", slug=p.slug) }}">{{ p.title }}</a>
       {% set count = pages_per_project[p.id] %}


### PR DESCRIPTION
Our proofers have requested more tools to search and manage the list of available projects. This commit adds a simple text form that performs case-insensitive substring matching against the list of projects.

The implementation itself is quite clumsy since it manages state in both JS data and in the order and attributes of HTML elements. I think this messy approach is acceptable given that this is a new feature and the actual logic is quite short. If our proofers ask for other filtering options in the future, we can clean this up.

Test plan: tried it on dev.

![image](https://user-images.githubusercontent.com/1429776/193431773-ae9dfde0-65b9-4952-b5a0-49f99c94762e.png)
