### PR TITLE
[proofing] Add moderator dashboard

### DIFF
--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -28,7 +28,7 @@
 
 
 {# Main-level sidebar. #}
-{% macro main_nav(active = none) %}
+{% macro main_nav(active = none, is_mod = false) %}
 {% macro _link(label, route, text) -%}
 {% if active == label %}<li class="font-bold text-black">{% else %}<li>{% endif %}
 <a href="{{ url_for(route) }}">{{ text }}</a>
@@ -51,6 +51,13 @@
   {{ _link('tagging', "proofing.tagging.index", _("Tagging")) }}
   {{ _link('talk', "proofing.talk", _("Talk")) }}
 </ul>
+
+{% if is_mod %}
+<h1 class="mt-2 font-bold">{{ _('Moderation') }}</h1>
+<ul class="list-disc pl-6">
+  {{ _link('stats', "proofing.stats", _("Statistics")) }}
+</ul>
+{% endif %}
 </nav>
 {% endmacro %}
 

--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -26,14 +26,25 @@
 </header>
 {% endmacro %}
 
-
-{# Main-level sidebar. #}
-{% macro main_nav(active = none, is_mod = false) %}
+{# Sidebar link #}
 {% macro _link(label, route, text) -%}
 {% if active == label %}<li class="font-bold text-black">{% else %}<li>{% endif %}
 <a href="{{ url_for(route) }}">{{ text }}</a>
 </li>
 {%- endmacro %}
+
+
+{# Sidebar shown on most proofing pages. #}
+{% macro main_nav(active = none, is_mod = false) %}
+
+{% if is_mod %}
+<nav class="rounded bg-slate-200 text-slate-500 mb-2 p-4 a-hover-underline text-sm">
+<h1 class="font-bold">{{ _('Moderation') }}</h1>
+<ul class="list-disc pl-6">
+  {{ _link('stats', "proofing.dashboard", _("Dashboard")) }}
+</ul>
+</nav>
+{% endif %}
 
 <nav class="rounded bg-slate-100 text-slate-500 p-4 a-hover-underline text-sm">
 <h1 class="font-bold">{{ _('Help') }}</h1>
@@ -51,13 +62,6 @@
   {{ _link('tagging', "proofing.tagging.index", _("Tagging")) }}
   {{ _link('talk', "proofing.talk", _("Talk")) }}
 </ul>
-
-{% if is_mod %}
-<h1 class="mt-2 font-bold">{{ _('Moderation') }}</h1>
-<ul class="list-disc pl-6">
-  {{ _link('stats', "proofing.stats", _("Statistics")) }}
-</ul>
-{% endif %}
 </nav>
 {% endmacro %}
 

--- a/ambuda/templates/macros/proofing.html
+++ b/ambuda/templates/macros/proofing.html
@@ -35,9 +35,9 @@
 
 
 {# Sidebar shown on most proofing pages. #}
-{% macro main_nav(active = none, is_mod = false) %}
+{% macro main_nav(active, current_user) %}
 
-{% if is_mod %}
+{% if current_user.is_moderator %}
 <nav class="rounded bg-slate-200 text-slate-500 mb-2 p-4 a-hover-underline text-sm">
 <h1 class="font-bold">{{ _('Moderation') }}</h1>
 <ul class="list-disc pl-6">

--- a/ambuda/templates/proofing/beginners-guide.html
+++ b/ambuda/templates/proofing/beginners-guide.html
@@ -27,7 +27,7 @@
 {% block title %}Beginner's guide to proofing | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('beginners') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('beginners', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/complete-guide.html
+++ b/ambuda/templates/proofing/complete-guide.html
@@ -78,7 +78,7 @@
 {% block title %}Complete guide to proofing | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('complete') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('complete', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/create-project.html
+++ b/ambuda/templates/proofing/create-project.html
@@ -22,7 +22,7 @@
 {% block title %}Create project | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('create') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('create', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/dashboard.html
+++ b/ambuda/templates/proofing/dashboard.html
@@ -1,4 +1,5 @@
 {% extends 'proofing/base-sidebar.html' %}
+{% import "macros/components.html" as mc %}
 {% import "macros/proofing.html" as m %}
 
 
@@ -10,7 +11,7 @@
 {% endmacro %}
 
 
-{% block title %}Stats | Ambuda{% endblock %}
+{% block title %}{{ mc.title(_('Dashboard')) }}{% endblock %}
 
 
 {% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
@@ -18,8 +19,8 @@
 
 {% block content %}
 {{ m.title_and_subtitle(
-    "Stats",
-    "Statistics about our proofing work") }}
+    "Dashboard",
+    "A summary of our proofing work") }}
 
 <div class="prose">
 <h2>Revisions</h2>
@@ -30,4 +31,16 @@
   {{ _number(num_revisions_7d, "Last 7 days") }}
   {{ _number(num_revisions_1d, "Last 1 day") }}
 </ul>
+
+
+<div class="prose">
+<h2>Contributors</h2>
+</div>
+
+<ul class="flex text-center justify-between">
+  {{ _number(num_contributors_30d, "Last 30 days") }}
+  {{ _number(num_contributors_7d, "Last 7 days") }}
+  {{ _number(num_contributors_1d, "Last 1 day") }}
+</ul>
+
 {% endblock %}

--- a/ambuda/templates/proofing/dashboard.html
+++ b/ambuda/templates/proofing/dashboard.html
@@ -14,7 +14,7 @@
 {% block title %}{{ mc.title(_('Dashboard')) }}{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('projects', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/editor-guide.html
+++ b/ambuda/templates/proofing/editor-guide.html
@@ -12,7 +12,7 @@
 {% block title %}Editor manual| Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('manual') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('manual', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/index.html
+++ b/ambuda/templates/proofing/index.html
@@ -21,7 +21,7 @@
 {% block title %}{{ mc.title(_('Ongoing projects')) }}{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('projects', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/projects/activity.html
+++ b/ambuda/templates/proofing/projects/activity.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ m.project_header_nested('Activity', project) }}
-{{ m.project_nav(project=project, active='activity', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='activity') }}
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
 
 {{ m.activity_log(recent_activity) }}

--- a/ambuda/templates/proofing/projects/activity.html
+++ b/ambuda/templates/proofing/projects/activity.html
@@ -7,7 +7,7 @@
 {% block title %}Activity: {{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('projects', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/projects/admin.html
+++ b/ambuda/templates/proofing/projects/admin.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ m.project_header_nested("Admin", project) }}
-{{ m.project_nav(project=project, active='admin', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='admin') }}
 
 <div class="prose">
 

--- a/ambuda/templates/proofing/projects/admin.html
+++ b/ambuda/templates/proofing/projects/admin.html
@@ -7,7 +7,7 @@
 {% block title %}Admin: {{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('projects', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/projects/batch-ocr-post.html
+++ b/ambuda/templates/proofing/projects/batch-ocr-post.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 {{ m.project_header_nested('OCR', project) }}
-{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='edit') }}
 
 {% set url = url_for('proofing.project.batch_ocr_status', task_id=task_id) %}
 <div id="progress" x-data="htmlPoller('{{ url }}')">

--- a/ambuda/templates/proofing/projects/batch-ocr.html
+++ b/ambuda/templates/proofing/projects/batch-ocr.html
@@ -11,7 +11,7 @@
 {{ components.flash_messages() }}
 
 {{ m.project_header_nested('OCR', project) }}
-{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='edit') }}
 
 <div class="prose">
   <p>Click the button below to run OCR on every unedited page.</p>

--- a/ambuda/templates/proofing/projects/download.html
+++ b/ambuda/templates/proofing/projects/download.html
@@ -5,7 +5,7 @@
 {% block title %}Download: {{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('projects', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/projects/download.html
+++ b/ambuda/templates/proofing/projects/download.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 {{ m.project_header_nested('Download', project) }}
-{{ m.project_nav(project=project, active='download', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='download') }}
 
 <div class="prose">
   <p>{% trans %}

--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ m.project_header_nested('Edit', project) }}
-{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='edit') }}
 
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
 {% set ocr_url = url_for("proofing.project.batch_ocr", slug=project.slug)  %}

--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -7,7 +7,7 @@
 {% block title %}Edit: {{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('projects', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/projects/search.html
+++ b/ambuda/templates/proofing/projects/search.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 {{ m.project_header_nested('Search', project) }}
-{{ m.project_nav(project=project, active='edit', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='edit') }}
 
 <div class="prose">
   <p>Use this simple search form to find typos across this project.</p>

--- a/ambuda/templates/proofing/projects/summary.html
+++ b/ambuda/templates/proofing/projects/summary.html
@@ -7,7 +7,7 @@
 {% block title %}{{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('projects', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/projects/summary.html
+++ b/ambuda/templates/proofing/projects/summary.html
@@ -14,7 +14,7 @@
 {{ components.flash_messages() }}
 
 <h1 class="font-bold text-3xl mb-4">{{ project.title }}</h1>
-{{ m.project_nav(project=project, active='summary', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='summary') }}
 
 {% if project.description %}
 <div class="prose">

--- a/ambuda/templates/proofing/recent-changes.html
+++ b/ambuda/templates/proofing/recent-changes.html
@@ -5,7 +5,7 @@
 {% block title %}Recent changes | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('changes') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('changes', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/stats.html
+++ b/ambuda/templates/proofing/stats.html
@@ -1,0 +1,55 @@
+{% extends 'proofing/base-sidebar.html' %}
+{% import "macros/proofing.html" as m %}
+
+
+{% macro _number(n, label) %}
+<li class="flex-1">
+  <div class="font-bold text-3xl">{{ n }}</div>
+  <div class="text-slate-500 text-sm">{{ label }}</div>
+</li>
+{% endmacro %}
+
+
+{% block title %}Stats | Ambuda{% endblock %}
+
+
+{% block sidebar %}{{ m.main_nav('projects') }}{% endblock %}
+
+
+{% block content %}
+{{ m.title_and_subtitle(
+    "Stats",
+    "Statistics about our proofing work") }}
+
+<div class="prose">
+<h2>Active users</h2>
+</div>
+
+<ul class="flex text-center justify-between">
+  {{ _number(num_active_users_30d, "Last 30 days") }}
+  {{ _number(num_active_users_7d, "Last 7 days") }}
+  {{ _number(num_active_users_1d, "Last 1 day") }}
+</ul>
+
+<ul>
+  {% for user in p1_users %}
+  <li>{{ user.username }}</li>
+  {% endfor %}
+</ul>
+
+<ul>
+  {% for user in p2_users %}
+  <li>{{ user.username }}</li>
+  {% endfor %}
+</ul>
+
+<div class="prose">
+<h2>Revisions</h2>
+</div>
+
+<ul class="flex text-center justify-between">
+  {{ _number(num_revisions_30d, "Last 30 days") }}
+  {{ _number(num_revisions_7d, "Last 7 days") }}
+  {{ _number(num_revisions_1d, "Last 1 day") }}
+</ul>
+{% endblock %}

--- a/ambuda/templates/proofing/stats.html
+++ b/ambuda/templates/proofing/stats.html
@@ -22,28 +22,6 @@
     "Statistics about our proofing work") }}
 
 <div class="prose">
-<h2>Active users</h2>
-</div>
-
-<ul class="flex text-center justify-between">
-  {{ _number(num_active_users_30d, "Last 30 days") }}
-  {{ _number(num_active_users_7d, "Last 7 days") }}
-  {{ _number(num_active_users_1d, "Last 1 day") }}
-</ul>
-
-<ul>
-  {% for user in p1_users %}
-  <li>{{ user.username }}</li>
-  {% endfor %}
-</ul>
-
-<ul>
-  {% for user in p2_users %}
-  <li>{{ user.username }}</li>
-  {% endfor %}
-</ul>
-
-<div class="prose">
 <h2>Revisions</h2>
 </div>
 

--- a/ambuda/templates/proofing/tagging/index.html
+++ b/ambuda/templates/proofing/tagging/index.html
@@ -3,7 +3,7 @@
 {% import "macros/proofing.html" as m %}
 
 
-{% block sidebar %}{{ m.main_nav('tagging') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('tagging', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/talk.html
+++ b/ambuda/templates/proofing/talk.html
@@ -7,7 +7,7 @@
 {% block title %}Talk | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/talk/board.html
+++ b/ambuda/templates/proofing/talk/board.html
@@ -7,7 +7,7 @@
 {% block title %}Talk: {{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/talk/board.html
+++ b/ambuda/templates/proofing/talk/board.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ m.project_header_nested('Talk', project) }}
-{{ m.project_nav(project=project, active='talk', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='talk') }}
 
 <div class="my-4">
 <a class="btn btn-basic" href="{{ url_for('proofing.talk.create_thread', slug=project.slug) }}">

--- a/ambuda/templates/proofing/talk/create-post.html
+++ b/ambuda/templates/proofing/talk/create-post.html
@@ -7,7 +7,7 @@
 {% block title %}Create post on {{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/talk/create-thread.html
+++ b/ambuda/templates/proofing/talk/create-thread.html
@@ -7,7 +7,7 @@
 {% block title %}Create thread on {{ project.title }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/talk/thread.html
+++ b/ambuda/templates/proofing/talk/thread.html
@@ -34,12 +34,12 @@
 {% block title %}{{ mc.title(thread.title) }}{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}
 {{ m.project_header_nested("Talk", project) }}
-{{ m.project_nav(project=project, active='talk', is_mod=current_user.is_moderator) }}
+{{ m.project_nav(project=project, active='talk') }}
 
 <header class="flex justify-between items-center bg-slate-100 p-4">
   <h1 class="text-xl font-bold">{{ thread.title }}</h1>

--- a/ambuda/templates/proofing/user/activity.html
+++ b/ambuda/templates/proofing/user/activity.html
@@ -16,7 +16,7 @@
 {{ components.flash_messages() }}
 {{ m.nested_header('Activity', user.username, url) }}
 
-{{ m.user_tabs(user=user, active='activity', is_mod=current_user.is_moderator) }}
+{{ m.user_tabs(user=user, active='activity') }}
 
 {% if recent_activity %}
 <div class="prose">

--- a/ambuda/templates/proofing/user/activity.html
+++ b/ambuda/templates/proofing/user/activity.html
@@ -7,7 +7,7 @@
 {% block title %}User: {{ user.username }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/user/admin.html
+++ b/ambuda/templates/proofing/user/admin.html
@@ -12,7 +12,7 @@
 {% block content %}
 {% set url = url_for('proofing.user.summary', username=user.username) %}
 {{ m.nested_header('Admin', user.username, url) }}
-{{ m.user_tabs(user=user, active='admin', is_mod=current_user.is_moderator) }}
+{{ m.user_tabs(user=user, active='admin') }}
 
 <p class="my-4">Set user permissions:</p>
 

--- a/ambuda/templates/proofing/user/admin.html
+++ b/ambuda/templates/proofing/user/admin.html
@@ -6,7 +6,7 @@
 {% block title %}User: {{ user.username }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/user/edit.html
+++ b/ambuda/templates/proofing/user/edit.html
@@ -12,7 +12,7 @@
 {% block content %}
 {% set base = url_for("proofing.user.summary", username=user.username) %}
 {{ m.nested_header('Edit', user.username, base) }}
-{{ m.user_tabs(user=user, active='about', is_mod=current_user.is_moderator) }}
+{{ m.user_tabs(user=user, active='about') }}
 
 <form method="POST">
   {{ form.csrf_token }}

--- a/ambuda/templates/proofing/user/edit.html
+++ b/ambuda/templates/proofing/user/edit.html
@@ -6,7 +6,7 @@
 {% block title %}Edit: {{ user.username }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/user/summary.html
+++ b/ambuda/templates/proofing/user/summary.html
@@ -6,7 +6,7 @@
 {% block title %}User: {{ user.username }} | Ambuda{% endblock %}
 
 
-{% block sidebar %}{{ m.main_nav('talk') }}{% endblock %}
+{% block sidebar %}{{ m.main_nav('talk', current_user=current_user) }}{% endblock %}
 
 
 {% block content %}

--- a/ambuda/templates/proofing/user/summary.html
+++ b/ambuda/templates/proofing/user/summary.html
@@ -12,7 +12,7 @@
 {% block content %}
 {{ m.title_and_subtitle(user.username) }}
 
-{{ m.user_tabs(user=user, active='about', is_mod=current_user.is_moderator) }}
+{{ m.user_tabs(user=user, active='about') }}
 
 {% if user.description %}
 <div class="prose border p-4 my-8">

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -309,9 +309,6 @@ def stats():
 
     return render_template(
         "proofing/stats.html",
-        num_active_users_30d=0,
-        num_active_users_7d=0,
-        num_active_users_1d=0,
         num_revisions_30d=num_revisions_30d,
         num_revisions_7d=num_revisions_7d,
         num_revisions_1d=num_revisions_1d,

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -17,7 +17,7 @@ from ambuda import database as db
 from ambuda import queries as q
 from ambuda.enums import SitePageStatus
 from ambuda.tasks import projects as project_tasks
-from ambuda.views.proofing.decorators import p2_required
+from ambuda.views.proofing.decorators import p2_required, moderator_required
 
 bp = Blueprint("proofing", __name__)
 
@@ -286,19 +286,25 @@ def talk():
     return render_template("proofing/talk.html", all_threads=all_threads)
 
 
-@bp.route("/stats/")
-def stats():
+@bp.route("/admin/dashboard/")
+@moderator_required
+def dashboard():
     now = datetime.now()
     days_ago_30d = now - timedelta(days=30)
     days_ago_7d = now - timedelta(days=7)
     days_ago_1d = now - timedelta(days=1)
 
     session = q.get_session()
+    bot = session.query(db.User).filter_by(username=consts.BOT_USERNAME).one()
+    bot_id = bot.id
 
     revisions_30d = (
         session.query(db.Revision)
-        .filter(db.Revision.created >= days_ago_30d)
-        .options(orm.load_only(db.Revision.id, db.Revision.created))
+        .filter(
+            (db.Revision.created >= days_ago_30d) & (db.Revision.author_id != bot_id)
+        )
+        .options(orm.load_only(db.Revision.created, db.Revision.author_id))
+        .order_by(db.Revision.created)
         .all()
     )
     revisions_7d = [x for x in revisions_30d if x.created >= days_ago_7d]
@@ -307,9 +313,16 @@ def stats():
     num_revisions_7d = len(revisions_7d)
     num_revisions_1d = len(revisions_1d)
 
+    num_contributors_30d = len({x.author_id for x in revisions_30d})
+    num_contributors_7d = len({x.author_id for x in revisions_7d})
+    num_contributors_1d = len({x.author_id for x in revisions_1d})
+
     return render_template(
-        "proofing/stats.html",
+        "proofing/dashboard.html",
         num_revisions_30d=num_revisions_30d,
         num_revisions_7d=num_revisions_7d,
         num_revisions_1d=num_revisions_1d,
+        num_contributors_30d=num_contributors_30d,
+        num_contributors_7d=num_contributors_7d,
+        num_contributors_1d=num_contributors_1d,
     )


### PR DESCRIPTION
This is a simple starting point for a more feature-rich dashboard that
will let moderators manage the proofing effort as a whole.

Test plan: unit tests and tried it on dev.

<img width="791" alt="image" src="https://user-images.githubusercontent.com/1429776/193475540-bb1ecf84-af6d-439a-97ad-6bd2a4dfa151.png">
