### PR TITLE
[bug] Use user script for padaccheda

### DIFF
--- a/ambuda/static/js/core.ts
+++ b/ambuda/static/js/core.ts
@@ -29,11 +29,16 @@ function transliterateElement($el, from: string, to: string) {
   });
 }
 
-// Transliterate mixed English/Sanskrit content.
-function transliterateHTMLString(s: string, outputScript: string) {
+// Transliterate mixed Latin/Devanagari content.
+function transliterateHTMLString(source: string, to: string) {
+  const from = 'devanagari';
+  if (from === to) return source;
+
   const $div = document.createElement('div');
-  $div.innerHTML = s;
-  transliterateElement($div, 'devanagari', outputScript);
+  $div.innerHTML = source;
+  $div.querySelectorAll('*').forEach((elem) => {
+    forEachSanskritTextNode(elem, (s) => Sanscript.t(s, from, to));
+  });
   return $div.innerHTML;
 }
 

--- a/test/js/core.test.js
+++ b/test/js/core.test.js
@@ -43,3 +43,15 @@ test('transliterateElement transliterates Sanskrit fields', () => {
   </div>
   `;
 });
+
+test('transliterateHTMLString transliterates Devanagari to HK', () => {
+  const text = '<div>संस्कृतम्</div>';
+  const output = core.transliterateHTMLString(text, 'hk');
+  expect(output).toBe('<div>संस्कृतम्:hk</div>');
+});
+
+test('transliterateHTMLString is a no-op if transliterating to Devanagari', () => {
+  const text = '<div>संस्कृतम्</div>';
+  const output = core.transliterateHTMLString(text, 'devanagari');
+  expect(output).toBe(text);
+});


### PR DESCRIPTION
The root cause was a bug in `transliterateHTMLString`. This has been fixed.

Test plan: new unit tests and tried it on dev.