### PR TITLE
[bug] Redefine x-model for dictionary sources

### DIFF
--- a/ambuda/templates/dictionaries/index.html
+++ b/ambuda/templates/dictionaries/index.html
@@ -42,7 +42,7 @@ different languages.
         {{ _('(choose dictionary)') }} <span class="text-xs">&#x25BC;</span>
     </div>
     <div x-show="showSourceSelector" class="dropdown-pane p-2 w-64">
-      {{ m.source_multiselect() }}
+      {{ m.source_multiselect('sources') }}
     </div>
   </div>
 

--- a/ambuda/templates/macros/dictionaries.html
+++ b/ambuda/templates/macros/dictionaries.html
@@ -59,7 +59,7 @@
 
 
 {# JS-only source selection widget. #}
-{% macro source_multiselect(x_model) %}
+{% macro source_multiselect(x_model = 'sources') %}
 <fieldset>
   <legend class="font-bold my-2">{{ _('Sanskrit-English') }}</legend>
   {{ _checkboxes(sources['en'], x_model) }}


### PR DESCRIPTION
This was accidentally set to the empty string while pushing out multi-dict support for the reader.

Test plan: tried it on dev.