### PR TITLE
[infra] Avoid MW download in Docker CI test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,13 @@ upgrade:
 	. env/bin/activate; alembic upgrade head
 	. env/bin/activate; python -m ambuda.seed.lookup
 
+# Seed the database with a minimal dataset for CI. We fetch data only if it is
+# hosted on GitHub. Other resources are less predictable.
+db-seed-ci: py-venv-check
+	python -m ambuda.seed.lookup
+	python -m ambuda.seed.texts.gretil
+	python -m ambuda.seed.dcs
+
 # Seed the database with just enough data for the devserver to be interesting.
 db-seed-basic: py-venv-check
 	python -m ambuda.seed.lookup

--- a/scripts/run_devserver_docker.sh
+++ b/scripts/run_devserver_docker.sh
@@ -18,7 +18,7 @@ if [ ! -f $DB_FILE_PATH ]; then
     python -m scripts.initialize_db
 
     # Add some starter data with a few basic seed scripts.
-    make db-seed-basic
+    make db-seed-ci
 
     # Create Alembic's migrations table.
     alembic ensure_version


### PR DESCRIPTION
This file is large, and downloading it on each PR push puts undue burden on a third-party server that isn't designed for a CI use case.

Test plan: run on GitHub.