### PR TITLE
[proofing] Add various help text

### DIFF
--- a/ambuda/templates/proofing/create-project-post.html
+++ b/ambuda/templates/proofing/create-project-post.html
@@ -13,7 +13,17 @@
 <div class="prose">
 <h1>Create new project</h1>
 
-<p class="text-sm">(This page updates every 5 seconds.)</p>
+{% if percent < 100 %}
+<p>{% trans %}
+We are currently creating your project. If you accidentally close this page,
+don't worry: your project will still be created.
+{% endtrans %}</p>
+
+<p>{% trans %}
+You can track your project's progress with the progress bar below. This
+progress bar updates every 5 seconds.
+{% endtrans %}</p>
+{% endif %}
 
 {% set url = url_for('proofing.create_project_status', task_id=task_id) %}
 <div x-data="htmlPoller('{{ url }}')">

--- a/ambuda/templates/proofing/create-project.html
+++ b/ambuda/templates/proofing/create-project.html
@@ -96,13 +96,25 @@ coming from?</p>
       {{ form.local_file }}
     </div>
 
-    <p class="my-4">We also need a title for this PDF:</p>
-    {{ form.local_title(class_="p-2 block w-full", placeholder="My cool title") }}
   </div>
 </fieldset>
 
 
-{{ step(3, "Verify") }}
+{{ step(3, "Describe") }}
+
+
+<div class="prose">
+<p>What is the title of this book? Please use the full title as it appears on
+the book's cover or title page.</p>
+</div>
+
+<fieldset class="p-4 bg-slate-100">
+  {{ form.local_title(class_="p-2 block w-full", placeholder="My book title") }}
+  <p></p>
+</fieldset>
+
+
+{{ step(4, "Verify") }}
 
 <div class="prose">
 <p>To the best of your knowledge, what is the license of this book?</p>


### PR DESCRIPTION
Before the upload, explicitly ask for the title as it appears in the printed book.

After upload, emphasize that uploads will continue in the background even
if the tab is closed.

<img width="774" alt="image" src="https://user-images.githubusercontent.com/1429776/193978898-c19622e9-6aa1-4ac6-a6d6-9905cabc8aa0.png">

<img width="821" alt="image" src="https://user-images.githubusercontent.com/1429776/193979013-4262aef1-6534-4087-b864-ef152a42060a.png">
