### PR TITLE
[proofing] Hide OCR button for pages with edits

### DIFF
--- a/ambuda/templates/macros/components.html
+++ b/ambuda/templates/macros/components.html
@@ -9,7 +9,7 @@
 {% endmacro %}
 
 
-{# Small warning box, e.g. for form errors. #}
+{# Large warning box, e.g. for form errors. #}
 {% macro div_warning() %}
 <div class="p-2 md:p-4 bg-red-100 border border-red-200 text-red-900 rounded my-4">
   {{ caller() }}
@@ -17,9 +17,17 @@
 {% endmacro %}
 
 
+{# Small notes box, e.g. for form info messages. #}
+{% macro p_note() %}
+<p class="p-2 bg-yellow-200 text-yellow-900 rounded my-4">
+  {{ caller() }}
+</p>
+{% endmacro %}
+
+
 {# Large notes box, e.g. for form info messages. #}
 {% macro div_note() %}
-<div class="p-2 md:p-4 bg-yellow-100 border border-yellow-300 rounded my-4">
+<div class="p-2 md:p-4 bg-yellow-200 text-yellow-900 rounded my-4">
   {{ caller() }}
 </div>
 {% endmacro %}

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -43,11 +43,12 @@
     {{ form.version }}
 
     {% if not has_edits %}
-    {# i18n: This should match the "Tools" and "Run OCR" translations in the proofing tool. #}
-    {% set command = _("Tools &rarr; Run OCR") %}
-    {% call site_components.p_note() %}{% trans %}
-    This page has not been edited yet. Run <i>{{ command }}</i> to get started.
-    {% endtrans %}{% endcall %}
+    {{ has_edits }}
+      {# i18n: This should match the "Tools" and "Run OCR" translations in the proofing tool. #}
+      {% set command = _("Tools &rarr; Run OCR") %}
+      {% call site_components.p_note() %}{% trans %}
+      This page has not been edited yet. Run <i>{{ command }}</i> to get started.
+      {% endtrans %}{% endcall %}
     {% endif %}
 
     {{ editor.menu_bar() }}

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -43,7 +43,6 @@
     {{ form.version }}
 
     {% if not has_edits %}
-    {{ has_edits }}
       {# i18n: This should match the "Tools" and "Run OCR" translations in the proofing tool. #}
       {% set command = _("Tools &rarr; Run OCR") %}
       {% call site_components.p_note() %}{% trans %}

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -42,6 +42,14 @@
     {{ form.csrf_token }}
     {{ form.version }}
 
+    {% if not has_edits %}
+    {# i18n: This should match the "Tools" and "Run OCR" translations in the proofing tool. #}
+    {% set command = _("Tools &rarr; Run OCR") %}
+    {% call site_components.p_note() %}{% trans %}
+    This page has not been edited yet. Run <i>{{ command }}</i> to get started.
+    {% endtrans %}{% endcall %}
+    {% endif %}
+
     {{ editor.menu_bar() }}
     <div :class="layoutClasses">
       {{ editor.text_box(form.content.data or "") }}

--- a/ambuda/templates/proofing/pages/editor-components.html
+++ b/ambuda/templates/proofing/pages/editor-components.html
@@ -1,3 +1,14 @@
+        {#
+      <button
+          type="button"
+          class="btn bg-sky-700 text-white m-2 hover:bg-sky-900"
+          @click="runOCR"
+          :disabled="isRunningOCR"
+          x-text="isRunningOCR ? '{{ _("Running OCR ...") }}' : '{{ _("Run OCR") }}'">
+        {{ _("Run OCR") }}
+      </button>
+      #}
+
 {# Components of the page editor.
 
 We use these macros both to keep `pages/edit` readable and so that we can embed
@@ -124,6 +135,23 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
     </div>
   </div>
 
+  <div x-data="{open: false}" class="relative">
+    <button class="{{ button_css }}"
+       @click.prevent="open=!open"
+       @click.outside="open=false">{{ _('Tools') }}</button>
+    <div x-show="open" class="dropdown-pane w-48">
+      <ul class="text-sm" @click.prevent="open=false">
+        <li>
+          <button class="dropdown-item"
+                  @click.prevent="runOCR"
+                  :disabled="isRunningOCR"
+                  x-text="isRunningOCR ? '{{ _("Running OCR ...") }}' : '{{ _("Run OCR") }}'">
+              </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+
   <div x-data="{open: false}" class="relative" @click.outside="open=false">
     <button class="{{ button_css }}"
        @click.prevent="open=!open">{{ _('Transliterator') }}</button>
@@ -191,17 +219,6 @@ Pass `class` explicitly so that Tailwind can regex-find it when it compiles. #}
 {% macro text_box(data) %}
 <div class="flex flex-col flex-1 border border-r-slate-400">
   <div class="bg-slate-200 flex justify-between">
-    <div>
-      <button
-          type="button"
-          class="btn bg-sky-700 text-white m-2 hover:bg-sky-900"
-          @click="runOCR"
-          :disabled="isRunningOCR"
-          {# i18n: When clicked, run OCR #}
-          x-text="isRunningOCR ? '{{ _("Running OCR ...") }}' : '{{ _("Run OCR") }}'">
-        {{ _("Run OCR") }}
-      </button>
-    </div>
     <div>
       {{ alpine_button("A<sup>+</sup>", "increaseTextSize") }}
       {{ alpine_button("A<sup>-</sup>", "decreaseTextSize") }}

--- a/ambuda/views/proofing/page.py
+++ b/ambuda/views/proofing/page.py
@@ -136,6 +136,7 @@ def edit_post(project_slug, page_slug):
         prev=prev,
         cur=cur,
         next=next,
+        has_edits=True,
         conflict=conflict,
     )
 

--- a/ambuda/views/proofing/page.py
+++ b/ambuda/views/proofing/page.py
@@ -76,7 +76,8 @@ def edit(project_slug, page_slug):
     status_names = {s.id: s.name for s in q.page_statuses()}
     form.status.data = status_names[cur.status_id]
 
-    if cur.revisions:
+    has_edits = bool(cur.revisions)
+    if has_edits:
         latest_revision = cur.revisions[-1]
         form.content.data = latest_revision.content
 
@@ -89,6 +90,7 @@ def edit(project_slug, page_slug):
         prev=prev,
         cur=cur,
         next=next,
+        has_edits=has_edits,
         is_r0=is_r0,
     )
 

--- a/ambuda/views/proofing/page.py
+++ b/ambuda/views/proofing/page.py
@@ -129,6 +129,12 @@ def edit_post(project_slug, page_slug):
             conflict = cur.revisions[-1]
             form.version.data = cur.version
 
+    has_edits = bool(cur.revisions)
+    is_r0 = cur.status.name == SitePageStatus.R0
+
+    # Keep args in sync with `edit`. (We can't unify these functions easily
+    # because one function requires login but the other doesn't. Helper
+    # functions don't have any obvious cutting points.
     return render_template(
         "proofing/pages/edit.html",
         form=form,


### PR DESCRIPTION
We want users to use OCR if they need to, but we don't want them to re-run OCR on an edited page. We also have less need for the prominent "Run OCR" button now that we have batch OCR.

New UX: If a page has no edits, show the user a help box prompting them to run OCR. If a page has edits already, hide the help box. OCR is always available under the `Tools` menu if it's really needed.

Test plan: unit tests and tried it on dev.

<img width="540" alt="image" src="https://user-images.githubusercontent.com/1429776/193984052-638c56ff-198d-4a93-afd7-a465efd7e796.png">
