### PR TITLE
[proofing] Hide proofing button for unauth users

### DIFF
--- a/ambuda/templates/macros/components.html
+++ b/ambuda/templates/macros/components.html
@@ -3,7 +3,7 @@
 
 {# Small warning box, e.g. for form errors. #}
 {% macro p_warning() %}
-<p class="p-2 bg-red-100 text-red-900 rounded my-4">
+<p class="p-2 bg-red-100 text-red-900 rounded my-4 a-underline">
   {{ caller() }}
 </p>
 {% endmacro %}

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -1,6 +1,6 @@
 {% extends 'proofing/base.html' %}
 {% import "macros/proofing.html" as m %}
-{% import "macros/components.html" as site_components %}
+{% import "macros/components.html" as mc %}
 {% import "proofing/pages/editor-components.html" as editor %}
 
 
@@ -24,7 +24,7 @@
 <article class="p-4">
   {% if not current_user.is_authenticated -%}
   {% set url = url_for('auth.register') %}
-  {% call site_components.p_warning() %}{% trans %}
+  {% call mc.p_warning() %}{% trans %}
   Since you are not logged in, some functions (such as the OCR button) have
   been disabled. To use all website features, please <a class="underline"
   href="{{ url }}">create an account</a>.
@@ -57,7 +57,7 @@
       {{ editor.image_box() }}
     </div>
 
-    <div class="mt-8 p-4 border bg-slate-200">
+    <div class="my-8 p-4 border bg-slate-200 rounded">
       {{ form.summary.label(class_="text-slate-600 mb-2 block") }}
       {{ form.summary(class_="block rounded bg-white w-full mb-4 p-2",
           placeholder=_("Fixed various OCR errors")) }}
@@ -77,18 +77,30 @@
         "peer-checked:bg-slate-100 peer-checked:text-gray-800 peer-checked:border-gray-300") }}
       </div>
 
+      {% if current_user.is_authenticated %}
       {% set cc0 = "https://creativecommons.org/publicdomain/zero/1.0/" %}
       <p class="my-4 text-sm">{% trans %}
       By saving your changes, you agree to release your contribution under the
       <a class="underline" href="{{ cc0 }}">CC0 (public domain) license</a>.
       {% endtrans %}</p>
+
       <input class="btn btn-submit"
              type="submit"
              value="{{ _('Publish changes') }}"
              @click="hasUnsavedChanges = false">
+      {% endif %}
     </div>
   </form>
 
+  {% if not current_user.is_authenticated %}
+  {% set create = url_for("auth.register") %}
+  {% set log_in = url_for("auth.sign_in") %}
+  {% call mc.p_warning() %}
+  Only registered users can save changes. <a href="{{ create }}">Create an
+      account</a> or <a href="{{ log_in }}">sign in</a> to save your
+  changes.
+  {% endcall %}
+  {% endif %}
 </article>
 
 <script src="https://cdn.jsdelivr.net/npm/openseadragon@3.1/build/openseadragon/openseadragon.min.js"></script>

--- a/ambuda/templates/proofing/pages/edit.html
+++ b/ambuda/templates/proofing/pages/edit.html
@@ -33,7 +33,7 @@
 
   {% set num_images = project.pages|length %}
   {{ editor.navigation_bar(page_context, page_number, image_number, num_images) }}
-  {{ site_components.flash_messages() }}
+  {{ mc.flash_messages() }}
 
   {% if conflict %}
   <pre class="p-2 bg-slate-100 my-4">{{ conflict.content }}</pre>
@@ -46,7 +46,7 @@
     {% if not has_edits %}
       {# i18n: This should match the "Tools" and "Run OCR" translations in the proofing tool. #}
       {% set command = _("Tools &rarr; Run OCR") %}
-      {% call site_components.p_note() %}{% trans %}
+      {% call mc.p_note() %}{% trans %}
       This page has not been edited yet. Run <i>{{ command }}</i> to get started.
       {% endtrans %}{% endcall %}
     {% endif %}

--- a/test/ambuda/views/proofing/test_page.py
+++ b/test/ambuda/views/proofing/test_page.py
@@ -10,6 +10,7 @@ def test_get_image_filesystem_path(flask_app):
 def test_edit__unauth(client):
     r = client.get("/proofing/test-project/1/")
     assert "Since you are not logged in" in r.text
+    assert "Publish changes" not in r.text
 
 
 def test_edit__auth(rama_client):


### PR DESCRIPTION
A few users have tried making changes, clicked submit, and found that their changes were lost. A proper flow here will prompt login and save user changes. But for now, just hide the button and add another warning.

Test plan: unit tests and tried it on dev.