### PR TITLE
[reader] Refactor reader.js

### DIFF
--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -22,6 +22,7 @@ from ambuda import checks, filters, queries
 from ambuda.consts import LOCALES
 from ambuda.mail import mailer
 from ambuda.utils import assets
+from ambuda.utils.json_serde import AmbudaJSONEncoder
 from ambuda.utils.url_converters import ListConverter
 from ambuda.views.about import bp as about
 from ambuda.views.api import bp as api
@@ -160,15 +161,5 @@ def create_app(config_env: str):
         }
     )
 
-    from flask import json
-    import dataclasses
-
-    class AmbudaJSONEncoder(json.JSONEncoder):
-        def default(self, o):
-            if dataclasses.is_dataclass(o):
-                return dataclasses.asdict(o)
-            return super().default(o)
-
     app.json_encoder = AmbudaJSONEncoder
-
     return app

--- a/ambuda/__init__.py
+++ b/ambuda/__init__.py
@@ -160,4 +160,15 @@ def create_app(config_env: str):
         }
     )
 
+    from flask import json
+    import dataclasses
+
+    class AmbudaJSONEncoder(json.JSONEncoder):
+        def default(self, o):
+            if dataclasses.is_dataclass(o):
+                return dataclasses.asdict(o)
+            return super().default(o)
+
+    app.json_encoder = AmbudaJSONEncoder
+
     return app

--- a/ambuda/database.py
+++ b/ambuda/database.py
@@ -6,9 +6,9 @@ from ambuda.enums import SiteRole  # NOQA F401
 from ambuda.models.auth import *  # NOQA F401,F403
 from ambuda.models.base import Base  # NOQA F401,F403
 from ambuda.models.blog import *  # NOQA F401,F403
-from ambuda.models.site import *  # NOQA F401,F403
 from ambuda.models.dictionaries import *  # NOQA F401,F403
 from ambuda.models.parse import *  # NOQA F401,F403
 from ambuda.models.proofing import *  # NOQA F401,F403
+from ambuda.models.site import *  # NOQA F401,F403
 from ambuda.models.talk import *  # NOQA F401,F403
 from ambuda.models.texts import *  # NOQA F401,F403

--- a/ambuda/static/css/style.css
+++ b/ambuda/static/css/style.css
@@ -72,7 +72,6 @@
   /* TEI <lg>, i.e. a Sanskrit verse. */
   s-lg {
     @apply block x-deva leading-normal;
-    @apply cursor-pointer;
   }
   /* TEI <l>, i.e. a line of Sanskrit verse. */
   s-l {

--- a/ambuda/static/css/style.css
+++ b/ambuda/static/css/style.css
@@ -66,9 +66,12 @@
 
   /* Custom elements. */
 
+  s-block {
+    @apply block mb-4;
+  }
   /* TEI <lg>, i.e. a Sanskrit verse. */
   s-lg {
-    @apply block x-deva leading-normal mb-4;
+    @apply block x-deva leading-normal;
     @apply cursor-pointer;
   }
   /* TEI <l>, i.e. a line of Sanskrit verse. */
@@ -82,46 +85,6 @@
   }
   s-w:hover {
     @apply underline;
-  }
-
-  s-block {
-    display: flex;
-    flex-wrap: wrap;
-  }
-  s-block > div {
-    @apply hidden;
-  }
-  s-block > div.mula {
-    @apply block;
-  }
-
-  /* In place view */
-  .in-place s-block.show-parsed > div.mula {
-    @apply hidden;
-  }
-  .in-place s-block.show-parsed > div.parsed {
-    @apply block;
-  }
-
-  /* Side by side view */
-  .side-by-side s-block.show-parsed > div {
-    @apply block flex-1 min-w-max; /* At smaller widths, verses will wrap */
-  }
-  .side-by-side s-block.show-parsed > div.mula > s-lg {
-    @apply cursor-auto;
-  }
-  .side-by-side#text--content {
-    @apply md:max-w-3xl;
-  }
-
-  .shown-side-by-side {
-    @apply hidden;
-  }
-  .side-by-side .hidden-side-by-side {
-    @apply hidden;
-  }
-  .side-by-side .shown-side-by-side {
-    @apply hidden;
   }
 
   /* Prose context */

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -125,7 +125,7 @@ export default () => ({
       const json = await resp.json();
       this.blocks = json.blocks;
     } else {
-      console.log("unhandled exception");
+      console.log('unhandled exception');
     }
   },
 
@@ -151,25 +151,22 @@ export default () => ({
   getParseLayoutClasses() {
     if (this.parseLayout === 'side-by-side') {
       return 'md:max-w-3xl';
-    } else {
-      return 'md:max-w-lg ';
     }
+    return 'md:max-w-lg ';
   },
   getBlockClasses(b) {
     if (b.showParse) {
       if (this.parseLayout === 'side-by-side') {
         return 'flex flex-wrap justify-between w-max';
       }
-    } else {
-      return 'cursor-pointer';
     }
+    return 'cursor-pointer';
   },
   getParseLayoutTogglerText() {
     if (this.parseLayout === 'side-by-side') {
       return 'Hide parse';
-    } else {
-      return 'Show original';
     }
+    return 'Show original';
   },
   getMulaClasses() {
     if (this.parseLayout === 'side-by-side') {
@@ -177,7 +174,6 @@ export default () => ({
     }
     return '';
   },
-
 
   showBlockMula(b) {
     // in-place --> showParse
@@ -215,7 +211,7 @@ export default () => ({
   },
 
   async showParsedBlock(blockID) {
-    const block = this.blocks.find((b) => b.id == blockID);
+    const block = this.blocks.find((b) => b.id === blockID);
 
     if (block.parse) {
       // Parse has already been fetched. Toggle state.
@@ -273,7 +269,7 @@ export default () => ({
   // Search a word in the dictionary and display the results to the user.
   submitDictionaryQuery() {
     if (!this.dictQuery) return;
-    searchDictionary(this.dictSources, this.dictQuery, this.script);
+    this.searchDictionary(this.dictSources, this.dictQuery, this.script);
   },
 
   /** Toggle the source selection widget's visibility. */

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -201,13 +201,18 @@ export default () => ({
   getParseLayoutClasses() {
     if (this.parseLayout === 'side-by-side') {
       return 'md:max-w-3xl';
+    } else {
+      return 'md:max-w-lg ';
     }
   },
-  getParseLayoutClassesForBlock() {
-    if (this.parseLayout === 'side-by-side') {
-      return 'flex flex-wrap justify-between w-max';
+  getBlockClasses(b) {
+    if (b.showParse) {
+      if (this.parseLayout === 'side-by-side') {
+        return 'flex flex-wrap justify-between w-max';
+      }
+    } else {
+      return 'cursor-pointer';
     }
-    return '';
   },
   getParseLayoutTogglerText() {
     if (this.parseLayout === 'side-by-side') {

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -291,23 +291,23 @@ export default () => ({
     // Parsed word: show details for this word.
     const $word = e.target.closest('s-w');
     if ($word) {
-      this.showWordPanel($word);
+      this.onClickWord($word);
       return;
     }
 
     // Block: show parse data for this block.
     const $block = e.target.closest('s-block');
     if ($block) {
-      this.showParsedBlock($block.id);
+      this.onClickBlock($block.id);
     }
   },
 
-  async showParsedBlock(blockID) {
+  async onClickBlock(blockID) {
     const block = this.blocks.find((b) => b.id === blockID);
 
+    // If we have parse data already, display it then return.
     if (block.parse) {
-      // Parse has already been fetched. Toggle state.
-      block.showParse = !block.showParse;
+      block.showParse = true;
       return;
     }
 
@@ -328,7 +328,7 @@ export default () => ({
   },
 
   // Show information for a clicked word.
-  async showWordPanel($word) {
+  async onClickWord($word) {
     const form = Sanscript.t($word.textContent, this.script, Script.Devanagari);
     const lemma = Sanscript.t($word.getAttribute('lemma'), Script.SLP1, Script.Devanagari);
     const parse = $word.getAttribute('parse');

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -198,6 +198,41 @@ export default () => ({
     this.saveSettings();
   },
 
+  getParseLayoutClasses() {
+    if (this.parseLayout === 'side-by-side') {
+      return 'md:max-w-3xl';
+    }
+  },
+  getParseLayoutClassesForBlock() {
+    if (this.parseLayout === 'side-by-side') {
+      return 'flex flex-wrap justify-between w-max';
+    }
+    return '';
+  },
+  getParseLayoutTogglerText() {
+    if (this.parseLayout === 'side-by-side') {
+      return 'Hide parse';
+    } else {
+      return 'Show original';
+    }
+  },
+  getMulaClasses() {
+    if (this.parseLayout === 'side-by-side') {
+      return 'mr-4';
+    }
+    return '';
+  },
+
+
+  showBlockMula(b) {
+    // in-place --> showParse
+    // otherwise --> true
+    if (this.parseLayout === 'in-place') {
+      return !b.showParse;
+    }
+    return true;
+  },
+
   // Generic click handler for multiple objects in the reader.
   async onClick(e) {
     // Don't run e.preventDefault by default, as the user might be clicking an
@@ -206,11 +241,14 @@ export default () => ({
     // Parsed word: show details for this word.
     const $word = e.target.closest('s-w');
     if ($word) {
+        console.log('1');
       this.showWordPanel($word);
       return;
     }
+
     // "Hide parse" link: hide the displayed parse.
     if (e.target.closest('.js--source')) {
+        console.log('2');
       e.preventDefault();
       const $block = e.target.closest('s-block');
       $block.classList.remove('show-parsed');
@@ -219,6 +257,7 @@ export default () => ({
     // Block: show parse data for this block.
     const $block = e.target.closest('s-block');
     if ($block) {
+        console.log('3');
       const block = this.blocks.find((b) => b.id == $block.id);
       showParsedBlock(block, this.script, () => {
         this.showSidebar = true;

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -112,6 +112,10 @@ function switchScript(oldScript, newScript) {
 
 const READER_CONFIG_KEY = 'reader';
 export default () => ({
+
+  // User preferences
+  // ----------------
+
   // Text size for body text in the reader.
   fontSize: 'md:text-xl',
   // Script for Sanskrit text in the reader.
@@ -121,7 +125,12 @@ export default () => ({
   // The dictionary sources to use when fetching.
   dictSources: ['mw'],
 
-  // (transient data)
+  // AJAX data
+  // ---------
+  blocks: [],
+
+  // Transient data
+  // --------------
 
   // Script value as stored on the <select> widget. We store this separately
   // from `script` since we currently need to know both fields in order to
@@ -151,6 +160,8 @@ export default () => ({
     if ($sidebar) {
       $sidebar.classList.remove('hidden');
     }
+
+    this.loadAjax();
   },
 
   // Parse application settings from local storage.
@@ -179,6 +190,18 @@ export default () => ({
       dictSources: this.dictSources,
     };
     localStorage.setItem(READER_CONFIG_KEY, JSON.stringify(settings));
+  },
+
+  async loadAjax() {
+    const url = '/api/texts/json/catuhshloki/all';
+    const resp = await fetch(url);
+    if (resp.ok) {
+      const json = await resp.json();
+      console.log(json.blocks);
+      this.blocks = json.blocks;
+    } else {
+      console.log("unhandled exception");
+    }
   },
 
   updateScript() {

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -157,7 +157,7 @@ export default () => ({
   getBlockClasses(b) {
     if (b.showParse) {
       if (this.parseLayout === 'side-by-side') {
-        return 'flex flex-wrap justify-between w-max';
+        return 'flex flex-wrap justify-between w-full';
       }
     }
     return 'cursor-pointer';

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -65,8 +65,7 @@ async function showParsedBlock(block, contentScript, onFailure) {
   }
 
   if (resp.ok) {
-    const rawText = await resp.text();
-    const text = transliterateHTMLString(rawText, contentScript);
+    const text = await resp.text();
     block.parse = text;
     block.showParse = true;
   } else {
@@ -185,7 +184,6 @@ export default () => ({
     const resp = await fetch(url);
     if (resp.ok) {
       const json = await resp.json();
-      console.log(json.blocks);
       this.blocks = json.blocks;
     } else {
       console.log("unhandled exception");
@@ -198,6 +196,9 @@ export default () => ({
     this.saveSettings();
   },
 
+  transliterated(devanagariHTML) {
+    return transliterateHTMLString(devanagariHTML, this.script);
+  },
   getParseLayoutClasses() {
     if (this.parseLayout === 'side-by-side') {
       return 'md:max-w-3xl';
@@ -246,14 +247,12 @@ export default () => ({
     // Parsed word: show details for this word.
     const $word = e.target.closest('s-w');
     if ($word) {
-        console.log('1');
       this.showWordPanel($word);
       return;
     }
 
     // "Hide parse" link: hide the displayed parse.
     if (e.target.closest('.js--source')) {
-        console.log('2');
       e.preventDefault();
       const $block = e.target.closest('s-block');
       $block.classList.remove('show-parsed');
@@ -262,7 +261,6 @@ export default () => ({
     // Block: show parse data for this block.
     const $block = e.target.closest('s-block');
     if ($block) {
-        console.log('3');
       const block = this.blocks.find((b) => b.id == $block.id);
       showParsedBlock(block, this.script, () => {
         this.showSidebar = true;

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -304,7 +304,12 @@ export default () => ({
       const text = await resp.text();
       block.parse = text;
       block.showParse = true;
+
+      // FIXME: move to alpine
+      const $container = $('#parse--response');
+      $container.innerHTML = '';
     } else {
+      // FIXME: move to alpine
       const $container = $('#parse--response');
       // FIXME: add i18n support
       $container.innerHTML = '<p>Sorry, this content is not available right now. (Server error)</p>';

--- a/ambuda/static/js/reader.js
+++ b/ambuda/static/js/reader.js
@@ -177,7 +177,7 @@ export default () => ({
     return Sanscript.t(devanagariStr, Script.Devanagari, this.script);
   },
 
-  // AJAX requests
+  // Ajax requests
   // =============
 
   /** Load text data from the server. */

--- a/ambuda/static/js/sortable-list.js
+++ b/ambuda/static/js/sortable-list.js
@@ -43,8 +43,8 @@ export default (defaultField) => ({
     const query = this.query.toLowerCase();
     // toLowerCase for case-insensitive matching.
     const newKeys = this.data
-          .filter((x) => x.title.includes(query))
-          .map((x) => x.key);
+      .filter((x) => x.title.includes(query))
+      .map((x) => x.key);
     this.displayed = new Set(newKeys);
   },
 

--- a/ambuda/templates/htmx/text-block.html
+++ b/ambuda/templates/htmx/text-block.html
@@ -1,3 +1,3 @@
 <s-block id="{{ block.id }}">
-  {{ block.html | safe }}
+  {{ block.mula | safe }}
 </s-block>

--- a/ambuda/templates/include/script-options.html
+++ b/ambuda/templates/include/script-options.html
@@ -1,6 +1,8 @@
+<option value="bengali">{{ _('Bengali') }}</option>
 <option value="devanagari" selected>{{ _('Devanagari') }}</option>
 <option value="iast">{{ _('Roman') }}</option>
 <option value="gujarati">{{ _('Gujarati') }}</option>
+<option value="gurmukhi">{{ _('Gurmukhi') }}</option>
 <option value="kannada">{{ _('Kannada') }}</option>
 <option value="malayalam">{{ _('Malayalam') }}</option>
 <option value="oriya">{{ _('Oriya') }}</option>

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -172,7 +172,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 {# FIXME: unify <article> and these three <div>s into fewer elements. #}
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
   {# Note: the "parseLayout" class must be kept in sync with the .side-by-side selector in the css file. #}
-  <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1" :class="parseLayout">
+  <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1" :class="getParseLayoutClasses">
   <div :class="fontSize">
 
   {{ header() }}
@@ -189,10 +189,12 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   {# Client-side logic. This is what most readers will see and use. #}
   <template x-for="b in blocks">
     <s-block :id="b.id">
-      <div x-show="!b.showParse" class="mula" x-html="b.mula"></div>
-      <div x-show="b.showParse" x-html="b.parse"></div>
+      <div :class="getParseLayoutClassesForBlock">
+        <div x-show="showBlockMula(b)" :class="getMulaClasses" x-html="b.mula"></div>
+        <div x-show="b.showParse" x-html="b.parse"></div>
+      </div>
       <span class="text-sm text-zinc-400 hover:underline" x-show="b.showParse">
-        <a href="#">Show original</a>
+        <a href="#" x-text="getParseLayoutTogglerText"></a>
       </span>
     </s-block>
   </template>

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -130,6 +130,17 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
       <div class="text-sm" x-html="parseDescription"></div>
 
       <form id="dict--form" class="mb-4" @submit.prevent="submitDictionaryQuery">
+
+        {# Dictionary input field (desktop only, to save space) #}
+        <div class="mb-2 hidden lg:flex">
+          <input name="q" type="text" placeholder="राम, ರಾಮ, ma, rAma, ..."
+              class="p-2 flex-1 bg-slate-100 rounded-tl rounded-bl"
+              x-model="dictQuery"
+              ></input>
+          <input type="submit" value="{{ _('Search') }}"
+          class="cursor-pointer btn-submit p-2 rounded-tr rounded-br"></input>
+        </div>
+
         <div x-cloak @click.outside="onClickOutsideOfSourceSelector"
             class="relative text-sm select-none inline-block">
           <div class="f-select bg-white lg:bg-slate-100 px-2 cursor-pointer inline-block"

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -174,16 +174,24 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   {# Note: the "parseLayout" class must be kept in sync with the .side-by-side selector in the css file. #}
   <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1" :class="parseLayout">
   <div :class="fontSize">
-  <div lang="sa">
-    {{ header() }}
+
+  {{ header() }}
+
+  {# Server-side logic. This will be hidden once the application loads. #}
+  <div x-show="blocks.length === 0">
     {% for block_ in html_blocks %}
     <s-block id="{{ block_.id }}">
       <div class="mula">{{ block_.html|safe }}</div>
     </s-block>
     {% endfor %}
   </div>
-  </div>
-  </div>
+
+  {# Client-side logic. This is what most readers will see and use. #}
+  <template x-for="b in blocks">
+    <s-block :id="b.id">
+      <div class="mula" x-html="b.mula"></div>
+    </s-block>
+  </template>
 
   {{ footer() }}
   {{ sidebar() }}

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -190,8 +190,8 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   <template x-for="b in blocks">
     <s-block :id="b.id">
       <div :class="getBlockClasses(b)">
-        <div x-show="showBlockMula(b)" :class="getMulaClasses" x-html="b.mula"></div>
-        <div x-show="b.showParse" x-html="b.parse"></div>
+        <div x-show="showBlockMula(b)" :class="getMulaClasses" x-html="transliterated(b.mula)"></div>
+        <div x-show="b.showParse" x-html="transliterated(b.parse)"></div>
       </div>
       <span class="text-sm text-zinc-400 hover:underline" x-show="b.showParse">
         <a href="#" x-text="getParseLayoutTogglerText"></a>

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -127,18 +127,9 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   <div>
     <div>
       <button class="block text-2xl p-2" @click="showSidebar = false">&times;</button>
-      <div id="parse--response" class="text-sm"></div>
+      <div class="text-sm" x-html="parseDescription"></div>
 
       <form id="dict--form" class="mb-4" @submit.prevent="submitDictionaryQuery">
-        <div class="flex mb-2 hidden lg:block">
-          <input name="q" type="text" placeholder="राम, ರಾಮ, ma, rAma, ..."
-              class="p-2 flex-1 bg-zinc-100 rounded-tl rounded-bl"
-              x-model="dictQuery"
-              ></input>
-          <input type="submit" value="{{ _('Search') }}"
-          class="bg-zinc-800 text-white p-2 rounded-tr rounded-br"></input>
-        </div>
-
         <div x-cloak @click.outside="onClickOutsideOfSourceSelector"
             class="relative text-sm select-none inline-block">
           <div class="f-select bg-white lg:bg-slate-100 px-2 cursor-pointer inline-block"
@@ -151,9 +142,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
         </div>
       </form>
     </div>
-    <div>
-      {{ m_dict.dict_target() }}
-    </div>
+    <div x-html="transliterated(dictionaryResponse)"></div>
   </div>
 </div>
 {% endmacro %}

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -172,7 +172,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 {# FIXME: unify <article> and these three <div>s into fewer elements. #}
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
   {# Note: the "parseLayout" class must be kept in sync with the .side-by-side selector in the css file. #}
-  <div id="text--content" class="md:text-xl mx-4 md:max-w-lg pb-16 lg:flex-1" :class="getParseLayoutClasses">
+  <div id="text--content" class="md:text-xl mx-4 pb-16 lg:flex-1" :class="getParseLayoutClasses">
   <div :class="fontSize">
 
   {{ header() }}
@@ -189,7 +189,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   {# Client-side logic. This is what most readers will see and use. #}
   <template x-for="b in blocks">
     <s-block :id="b.id">
-      <div :class="getParseLayoutClassesForBlock">
+      <div :class="getBlockClasses(b)">
         <div x-show="showBlockMula(b)" :class="getMulaClasses" x-html="b.mula"></div>
         <div x-show="b.showParse" x-html="b.parse"></div>
       </div>

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -189,7 +189,11 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   {# Client-side logic. This is what most readers will see and use. #}
   <template x-for="b in blocks">
     <s-block :id="b.id">
-      <div class="mula" x-html="b.mula"></div>
+      <div x-show="!b.showParse" class="mula" x-html="b.mula"></div>
+      <div x-show="b.showParse" x-html="b.parse"></div>
+      <span class="text-sm text-zinc-400 hover:underline" x-show="b.showParse">
+        <a href="#">Show original</a>
+      </span>
     </s-block>
   </template>
 

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -160,7 +160,6 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 {% block main %}
 {# FIXME: unify <article> and these three <div>s into fewer elements. #}
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
-  {# Note: the "parseLayout" class must be kept in sync with the .side-by-side selector in the css file. #}
   <div id="text--content" class="md:text-xl mx-4 pb-16 lg:flex-1" :class="getParseLayoutClasses">
   <div :class="fontSize">
 
@@ -183,10 +182,12 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
         <div x-show="b.showParse" x-html="transliterated(b.parse)"></div>
       </div>
       <span class="text-sm text-zinc-400 hover:underline" x-show="b.showParse">
-        <a href="#" x-text="getParseLayoutTogglerText"></a>
+        <a @click.prevent href="#" x-text="getParseLayoutTogglerText"></a>
       </span>
     </s-block>
   </template>
+
+  </div></div>
 
   {{ footer() }}
   {{ sidebar() }}

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -66,7 +66,7 @@ or in their own modal window. #}
   </div>
   <div class="text-sm border-r px-4">
     <span class="hidden md:inline">{{ _('Script:') }}</span>
-    <select id="switch-sa" class="p-1" @change="updateScript" x-model="uiScript">
+    <select id="switch-sa" class="p-1" @change="saveSettings" x-model="script">
       {% include 'include/script-options.html' %}
     </select>
   </div>
@@ -115,7 +115,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 #}
 {% macro sidebar() %}
 <div id="sidebar" class="
-    hidden overscroll-contain
+    overscroll-contain
     fixed top-1/2 bottom-0 left-0 right-0
     flex flex-col flex-1
     p-4 overflow-auto
@@ -123,13 +123,21 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
     md:text-base lg:border-t-0 lg:bg-white
     lg:sticky lg:top-10 lg:max-w-lg lg:h-full-minus-nav lg:mr-8 lg:pl-8 lg:border-l
     lg:z-0"
-    x-show="showSidebar" x-transition.opacity>
+    x-show="showSidebar" x-transition.opacity x-cloak>
   <div>
     <div>
       <button class="block text-2xl p-2" @click="showSidebar = false">&times;</button>
-      <div class="text-sm" x-html="parseDescription"></div>
+      <div class="text-sm" x-show="wordAnalysis.form">
+        <header>
+          <h1 class="text-xl" lang="sa" x-text="transliterateStr(wordAnalysis.form)"></h1>
+          <p class="mb-8">
+            <span lang="sa" x-text="transliterateStr(wordAnalysis.lemma)"></span>
+            <span x-text="wordAnalysis.parse"></span>
+          </p>
+        </header>
+      </div>
 
-      <form id="dict--form" class="mb-4" @submit.prevent="submitDictionaryQuery">
+      <form id="dict--form" class="mb-4" @submit.prevent="searchDictionary">
 
         {# Dictionary input field (desktop only, to save space) #}
         <div class="mb-2 hidden lg:flex">
@@ -153,7 +161,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
         </div>
       </form>
     </div>
-    <div x-html="transliterated(dictionaryResponse)"></div>
+    <div x-html="transliterateHTML(dictionaryResponse)"></div>
   </div>
 </div>
 {% endmacro %}
@@ -171,7 +179,8 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 {% block main %}
 {# FIXME: unify <article> and these three <div>s into fewer elements. #}
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
-  <div id="text--content" class="md:text-xl mx-4 pb-16 lg:flex-1" :class="getParseLayoutClasses">
+  <div id="text--content" class="md:text-xl mx-4 pb-16 lg:flex-1 md:max-w-xl"
+      :class="getParseLayoutClasses">
   <div :class="fontSize">
 
   {{ header() }}
@@ -180,7 +189,7 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   <div x-show="blocks.length === 0">
     {% for block_ in html_blocks %}
     <s-block id="{{ block_.id }}">
-      <div class="mula">{{ block_.html|safe }}</div>
+      <div class="mula">{{ block_.mula|safe }}</div>
     </s-block>
     {% endfor %}
   </div>
@@ -189,8 +198,8 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   <template x-for="b in blocks">
     <s-block :id="b.id">
       <div :class="getBlockClasses(b)">
-        <div x-show="showBlockMula(b)" :class="getMulaClasses" x-html="transliterated(b.mula)"></div>
-        <div x-show="b.showParse" x-html="transliterated(b.parse)"></div>
+        <div x-show="showBlockMula(b)" :class="getMulaClasses" x-html="transliterateHTML(b.mula)"></div>
+        <div x-show="b.showParse" x-html="transliterateHTML(b.parse)"></div>
       </div>
       <span class="text-sm text-zinc-400 hover:underline" x-show="b.showParse">
         <a @click.prevent href="#" x-text="getParseLayoutTogglerText"></a>
@@ -203,6 +212,9 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   {{ footer() }}
   {{ sidebar() }}
 </article>
+
+{# Serialize the data above so we can use it without a second network call. #}
+<script id="payload" type="application/json">{{ json_payload|safe }}</script>
 {% endblock %}
 
 {# Hide footer because we have a position:fixed nav "footer" already. #}

--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -127,6 +127,8 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
   <div>
     <div>
       <button class="block text-2xl p-2" @click="showSidebar = false">&times;</button>
+      <div id="parse--response" class="text-sm"></div>
+
       <div class="text-sm" x-show="wordAnalysis.form">
         <header>
           <h1 class="text-xl" lang="sa" x-text="transliterateStr(wordAnalysis.form)"></h1>

--- a/ambuda/utils/json_serde.py
+++ b/ambuda/utils/json_serde.py
@@ -1,0 +1,12 @@
+import dataclasses
+
+from flask import json
+
+
+class AmbudaJSONEncoder(json.JSONEncoder):
+    """Extend Flask's default encoder to support dataclasses."""
+
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        return super().default(o)

--- a/ambuda/utils/xml.py
+++ b/ambuda/utils/xml.py
@@ -90,7 +90,7 @@ class Block:
     #: The block's HTML id.
     id: str
     #: HTML content for the given block.
-    html: str
+    mula: str
 
 
 def _delete(xml: ET.Element):
@@ -390,4 +390,4 @@ def transform_text_block(block_blob: str) -> Block:
     # namespaces. So, hard-code it like this:
     id = xml.attrib.get("{http://www.w3.org/XML/1998/namespace}id", "")
     html = transform(xml, transforms=tei_xml)
-    return Block(id=id, html=html)
+    return Block(id=id, mula=html)

--- a/ambuda/views/proofing/main.py
+++ b/ambuda/views/proofing/main.py
@@ -17,7 +17,7 @@ from ambuda import database as db
 from ambuda import queries as q
 from ambuda.enums import SitePageStatus
 from ambuda.tasks import projects as project_tasks
-from ambuda.views.proofing.decorators import p2_required, moderator_required
+from ambuda.views.proofing.decorators import moderator_required, p2_required
 
 bp = Blueprint("proofing", __name__)
 

--- a/ambuda/views/proofing/tagging.py
+++ b/ambuda/views/proofing/tagging.py
@@ -75,7 +75,7 @@ def edit_block(text_slug, block_slug):
     if block_parse is None:
         abort(404)
 
-    mula = xml.transform_text_block(block.xml).html
+    mula = xml.transform_text_block(block.xml).mula
     tokens = word_parses.extract_tokens(block_parse.data)
 
     form = EditBlockForm()

--- a/ambuda/views/reader/texts.py
+++ b/ambuda/views/reader/texts.py
@@ -1,6 +1,6 @@
 """Views related to texts: title pages, sections, verses, etc."""
 
-from flask import Blueprint, abort, render_template
+from flask import Blueprint, abort, render_template, jsonify
 from indic_transliteration import sanscript
 
 import ambuda.database as db
@@ -165,3 +165,17 @@ def block_htmx(text_slug, block_slug):
         "htmx/text-block.html",
         block=html_block,
     )
+
+
+@api.route("/texts/json/<text_slug>/<section_slug>")
+def reader_json(text_slug, section_slug):
+    text_ = q.text(text_slug)
+    if text_ is None:
+        abort(404)
+
+    cur = q.text_section(text_.id, section_slug)
+    with q.get_session() as _:
+        html_blocks = [xml.transform_text_block(b.xml) for b in cur.blocks]
+
+    data = {"blocks": html_blocks}
+    return jsonify(data)

--- a/ambuda/views/reader/texts.py
+++ b/ambuda/views/reader/texts.py
@@ -1,12 +1,16 @@
 """Views related to texts: title pages, sections, verses, etc."""
 
-from flask import Blueprint, abort, render_template, jsonify
+import dataclasses
+import json
+
+from flask import Blueprint, abort, jsonify, render_template
 from indic_transliteration import sanscript
 
 import ambuda.database as db
 import ambuda.queries as q
 from ambuda.consts import TEXT_CATEGORIES
 from ambuda.utils import xml
+from ambuda.utils.json_serde import AmbudaJSONEncoder
 from ambuda.views.api import bp as api
 
 # A hacky list that decides which texts have parse data.
@@ -138,12 +142,15 @@ def section(text_slug, section_slug):
 
     has_no_parse = text.slug in HAS_NO_PARSE
 
+    json_payload = json.dumps({"blocks": html_blocks}, cls=AmbudaJSONEncoder)
+
     return render_template(
         "texts/section.html",
         text=text,
         prev=prev,
         section=cur,
         next=next_,
+        json_payload=json_payload,
         html_blocks=html_blocks,
         has_no_parse=has_no_parse,
         is_single_section_text=is_single_section_text,
@@ -167,8 +174,10 @@ def block_htmx(text_slug, block_slug):
     )
 
 
-@api.route("/texts/json/<text_slug>/<section_slug>")
+@api.route("/texts/<text_slug>/<section_slug>")
 def reader_json(text_slug, section_slug):
+    # NOTE: currently unused, since we bootstrap from a JSON blob in the
+    # original request.
     text_ = q.text(text_slug)
     if text_ is None:
         abort(404)

--- a/ambuda/views/site.py
+++ b/ambuda/views/site.py
@@ -2,8 +2,8 @@
 
 from flask import Blueprint, redirect, render_template, request, session, url_for
 
-from ambuda.consts import LOCALES
 from ambuda import queries as q
+from ambuda.consts import LOCALES
 
 bp = Blueprint("site", __name__)
 

--- a/test/ambuda/utils/test_json_serde.py
+++ b/test/ambuda/utils/test_json_serde.py
@@ -1,0 +1,15 @@
+import json
+from dataclasses import dataclass
+
+from ambuda.utils.json_serde import AmbudaJSONEncoder
+
+
+@dataclass
+class Dummy:
+    foo: str
+    bar: str
+
+
+def test_encode():
+    dummy = Dummy(foo="oof", bar="rab")
+    assert json.dumps(dummy, cls=AmbudaJSONEncoder) == '{"foo": "oof", "bar": "rab"}'

--- a/test/ambuda/utils/test_xml.py
+++ b/test/ambuda/utils/test_xml.py
@@ -46,7 +46,7 @@ def test_transform_text_block():
     blob = '<lg xml:id="Test">verse</lg>'
     block = x.transform_text_block(blob)
     assert block.id == "Test"
-    assert block.html == "<s-lg>verse</s-lg>"
+    assert block.mula == "<s-lg>verse</s-lg>"
 
 
 def test_transform():

--- a/test/js/reader.test.js
+++ b/test/js/reader.test.js
@@ -1,8 +1,8 @@
 import { $ } from '@/core.ts';
-import Reader from '@/reader';
+import Reader, { Layout, getBlockSlug } from '@/reader';
 
 const sampleHTML = `
-<div>
+<body>
   <div id="text--content">
     <p lang="sa">granthaH</p>
   </div>
@@ -10,21 +10,50 @@ const sampleHTML = `
     <input type="text" name="q"></input>
   </form>
   <div id="sidebar"><span lang="sa">padam</span> English</div>
-</div>
+
+  <script id="payload" type="application/json">
+  {
+    "blocks": [
+      { "id": "1", "mula": "<s-lg>verse 1</s-lg>" }
+    ]
+  }
+  </script>
+</body>
 `;
 
+// Can't modify existing `window.location` -- delete it so that we can mock it.
+// (See beforeEach and the tests below.)
+delete window.location;
+
+window.IMAGE_URL = 'IMAGE_URL';
 window.Sanscript = {
   t: jest.fn((s, from, to) => `${s}:${to}`),
 }
+window.fetch = jest.fn(async (url) => {
+  if (url === '/api/texts/sample-text/error') {
+    return { ok: false };
+  }
+  if (url === '/api/texts/sample-text/1') {
+    return {
+      ok: true,
+      json: async () => ({
+          blocks: [
+            { id: "1.1", mula: "text for 1.1" },
+            { id: "1.2", mula: "text for 1.2" },
+          ],
+      })
+    }
+  }
+});
 
 beforeEach(() => {
   window.localStorage.clear();
+  document.write(sampleHTML);
 });
 
 test('Reader can be created', () => {
   const r = Reader()
   r.init();
-  expect(r.script).toBe(r.uiScript);
 });
 
 test('saveSettings and loadSettings work as expected', () => {
@@ -58,14 +87,81 @@ test('loadSettings works if localStorage data is corrupt', () => {
   // No error -- OK
 });
 
-test('updateScript transliterates and updates settings', () => {
-  document.write(sampleHTML);
+test('loadAjax sets properties correctly', async () => {
+  window.location = new URL('https://ambuda.org/texts/sample-text/1');
 
-  const r = Reader()
-  r.init();
-  r.uiScript = 'kannada';
-  r.updateScript();
+  const r = Reader();
+  await r.loadAjax();
+  expect(r.blocks).toEqual([
+    { id: "1.1", mula: "text for 1.1" },
+    { id: "1.2", mula: "text for 1.2" },
+  ]);
+});
 
-  expect($('#text--content').textContent.trim()).toBe('granthaH:kannada');
-  expect($('#sidebar').textContent).toBe('padam:kannada English');
+test("loadAjax doesn't throw an error on a bad URL", async () => {
+  window.location = new URL('https://ambuda.org/texts/sample-text/error');
+
+  const r = Reader();
+  await r.loadAjax();
+  expect(r.blocks).toEqual([]);
+});
+
+test('transliterateHTML transliterates with the current script', () => {
+  const r = Reader();
+  r.script = 'kannada';
+  expect(r.transliterateHTML('<div>test</div>')).toBe('<div>test:kannada</div>');
+});
+
+test('transliterateStr transliterates with the current script', () => {
+  const r = Reader();
+  r.script = 'kannada';
+  expect(r.transliterateStr('test')).toBe('test:kannada');
+  expect(r.transliterateStr('')).toBe('');
+});
+
+test('getBlockSlug works', () => {
+  expect(getBlockSlug('A.1.1')).toBe('1.1');
+  expect(getBlockSlug('A.1')).toBe('1');
+  expect(getBlockSlug('A.all')).toBe('all');
+});
+
+// Layout tests
+
+test('CSS for parse layout is as expected', () => {
+  const r = Reader();
+
+  r.parseLayout = Layout.InPlace;
+  expect(r.getMulaClasses()).toBe('');
+  expect(r.getParseLayoutTogglerText()).toBe('Show original');
+  expect(r.getParseLayoutClasses()).toMatch('');
+
+  expect(r.showBlockMula({ showParse: false })).toBe(true);
+  expect(r.getBlockClasses({ showParse: false })).toMatch('pointer');
+
+  expect(r.showBlockMula({ showParse: true })).toBe(false);
+  expect(r.getBlockClasses({ showParse: true })).toBe('');
+
+  r.parseLayout = Layout.SideBySide;
+  expect(r.getMulaClasses()).toBe('mr-4');
+  expect(r.getParseLayoutTogglerText()).toBe('Hide parse');
+  expect(r.getParseLayoutClasses()).toMatch('3xl');
+
+  expect(r.showBlockMula({ showParse: false })).toBe(true);
+  expect(r.getBlockClasses({ showParse: false })).toMatch('pointer');
+
+  expect(r.showBlockMula({ showParse: true })).toBe(true);
+  expect(r.getBlockClasses({ showParse: true })).toMatch('flex');
+});
+
+// Sidebar tests
+
+test('toggleSourceSelector works', () => {
+  const r = Reader();
+  r.showDictSourceSelector = false;
+
+  r.toggleSourceSelector();
+  expect(r.showDictSourceSelector).toBe(true);
+
+  r.toggleSourceSelector();
+  expect(r.showDictSourceSelector).toBe(false);
 });

--- a/test/js/reader.test.js
+++ b/test/js/reader.test.js
@@ -216,14 +216,27 @@ test('CSS for parse layout is as expected', () => {
 
 // Click handlers
 
-test('showParseBlock works as expected on normal data', async () => {
+test('onClickBlock fetches and displays parse data', async () => {
   window.location = new URL('https://ambuda.org/texts/sample-text/1');
 
   const r = Reader();
   await r.fetchBlocks();
-  await r.showParsedBlock("A.1.1");
+  await r.onClickBlock("A.1.1");
 
   expect(r.blocks[0].parse).toBe("<p>parse for 1.1</p>");
+  expect(r.blocks[0].showParse).toBe(true);
+});
+
+
+test('onClickBlock toggles if parse data already exists', async () => {
+  window.location = new URL('https://ambuda.org/texts/sample-text/1');
+
+  const r = Reader();
+  await r.fetchBlocks();
+  await r.onClickBlock("A.1.1");
+  r.blocks[0].showParse = false;
+
+  r.onClickBlock("A.1.1");
   expect(r.blocks[0].showParse).toBe(true);
 });
 
@@ -237,5 +250,22 @@ test('toggleSourceSelector works', () => {
   expect(r.showDictSourceSelector).toBe(true);
 
   r.toggleSourceSelector();
+  expect(r.showDictSourceSelector).toBe(false);
+});
+
+test('onClickOutsideOfSourceSelector toggles if visible', async () => {
+  const r = Reader();
+  r.showDictSourceSelector = true;
+  r.dictionaryResponse = null;
+
+  await r.onClickOutsideOfSourceSelector();
+  expect(r.showDictSourceSelector).toBe(false);
+});
+
+test('onClickOutsideOfSourceSelector is a no-op otherwise', async () => {
+  const r = Reader();
+  r.showDictSourceSelector = false;
+
+  await r.onClickOutsideOfSourceSelector();
   expect(r.showDictSourceSelector).toBe(false);
 });

--- a/test/js/reader.test.js
+++ b/test/js/reader.test.js
@@ -6,6 +6,7 @@ const sampleHTML = `
   <div id="text--content">
     <p lang="sa">granthaH</p>
   </div>
+  <div id="parse--response"></div>
   <form id="dict--form">
     <input type="text" name="q"></input>
   </form>
@@ -96,6 +97,27 @@ test('loadSettings works if localStorage data is corrupt', () => {
   // No error -- OK
 });
 
+// Utility functions
+
+test('transliterateHTML transliterates with the current script', () => {
+  const r = Reader();
+  r.script = 'kannada';
+  expect(r.transliterateHTML('<div>test</div>')).toBe('<div>test:kannada</div>');
+});
+
+test('transliterateStr transliterates with the current script', () => {
+  const r = Reader();
+  r.script = 'kannada';
+  expect(r.transliterateStr('test')).toBe('test:kannada');
+  expect(r.transliterateStr('')).toBe('');
+});
+
+test('getBlockSlug works', () => {
+  expect(getBlockSlug('A.1.1')).toBe('1.1');
+  expect(getBlockSlug('A.1')).toBe('1');
+  expect(getBlockSlug('A.all')).toBe('all');
+});
+
 // Ajax calls
 
 test('fetchBlocks sets properties correctly', async () => {
@@ -164,28 +186,7 @@ test("fetchBlockParse shows an error if the word can't be found", async () => {
   expect(ok).toBe(false);
 });
 
-// Utilities
-
-test('transliterateHTML transliterates with the current script', () => {
-  const r = Reader();
-  r.script = 'kannada';
-  expect(r.transliterateHTML('<div>test</div>')).toBe('<div>test:kannada</div>');
-});
-
-test('transliterateStr transliterates with the current script', () => {
-  const r = Reader();
-  r.script = 'kannada';
-  expect(r.transliterateStr('test')).toBe('test:kannada');
-  expect(r.transliterateStr('')).toBe('');
-});
-
-test('getBlockSlug works', () => {
-  expect(getBlockSlug('A.1.1')).toBe('1.1');
-  expect(getBlockSlug('A.1')).toBe('1');
-  expect(getBlockSlug('A.all')).toBe('all');
-});
-
-// Layout tests
+// `parseLayout` CSS tests
 
 test('CSS for parse layout is as expected', () => {
   const r = Reader();
@@ -213,7 +214,20 @@ test('CSS for parse layout is as expected', () => {
   expect(r.getBlockClasses({ showParse: true })).toMatch('flex');
 });
 
-// Sidebar tests
+// Click handlers
+
+test('showParseBlock works as expected on normal data', async () => {
+  window.location = new URL('https://ambuda.org/texts/sample-text/1');
+
+  const r = Reader();
+  await r.fetchBlocks();
+  await r.showParsedBlock("A.1.1");
+
+  expect(r.blocks[0].parse).toBe("<p>parse for 1.1</p>");
+  expect(r.blocks[0].showParse).toBe(true);
+});
+
+// Dropdown handlers
 
 test('toggleSourceSelector works', () => {
   const r = Reader();


### PR DESCRIPTION
This commit refactors our reader code to better make use of Alpine. The changes here impose a simple reactive dataflow where the source of truth is whatever is stored on the Alpine application object.


# Why do this now?

The reader.js code is manageable but just barely so. The current data model makes it difficult to reason about the application state and write tests. By doing more of the heavy lifting in Alpine and its reactive data model, we can simplify several parts of the code while maintaining the same functionality and making it easier to build new features.


# Summary of changes

HTML:
- Use `x-cloak`, `template`, and other Alpine devices to more compactly describe JS-specific logic.
- Include serialized JSON data in `texts/section.html`, which we use to initiaiize the Alpine app.
- Move various HTML fragments from `reader.js` into `texts/section.html`.

JavaScript:
- Move all application data int the Alpine application. This is all we need to do for Alpine to add reactive data bindings for our application.
- Transliterate by calling `transliterateHTML` and `transliterateStr` functions that depend on `this.script`. Application data is always stored in Devanagari, which means that we can now support scripts like Gurmukhi and Bengali that don't losslessly round-trip. Because of the dependency on `this.script`, these functions will rerun whenever `this.script` changes.
- Remove `this.uiScript`, since it is no longer necessary.
- Move common string constants into the pseudo-enums `Layout` and `Script`.

Python:
- Add support for serializing dataclasses by simply using `.asdict()`.
- [unused] Add a new API endpoint that fetches JSON data for a section. I used this during testing, but it's no longer on any production path. However, we'll pick it up in a future PR.

CSS:
- Remove the previous `side-by-side` and `in-place` classes and move this logic into `reader.js`

Overall:
- Add various comments to make the logic here clearer.


# Differences from prod

- [feature] Add support for Bengali and Gurmukhi.
- [regression] Text and section titles are not transliterated. I'll fix this in a follow-up PR to avoid adding to an already complex PR.
- [css] Minor changes to the side-by-side layout.
- [css] Minor color and spacing changes in the dictionary sidebar.


# Future plans

- Support transliteration for text and section titles.
- Add transitions from section to section for a nicer UX. (The idea is that after initial load, each request is just for JSON data as opposed to the entire page.)
- Encode application state in the URL so that we can link to specific views (e.g. sidebar open, specific word clicked)
- When a verse is clicked, show padaccheda only for the clicked chunk of text, as opposed to the entire block. This could potentially let us remove the in-place vs. side-by-side logic if the UX satisfies.


# Test plan

I added unit tests to increase the overall statement coverage for `reader.js` from 30% to 50%. In addition, I tested the following behaviors on dev:

- Simple page load.
- Switch between multiple scripts.
- Switch between multiple parse layouts.
- Click on multiple block.
- Click on multiple parsed words.
- Various permutations of the above.