### PR TITLE
[reader] Fix long text rendering on mobile

### DIFF
--- a/ambuda/templates/texts/section.html
+++ b/ambuda/templates/texts/section.html
@@ -191,7 +191,8 @@ lg:top-10 is to vertically center the sidebar when sticky scrolling.
 
 {# FIXME: unify <article> and these three <div>s into fewer elements. #}
 <article lang="sa" class="flex justify-around mb-32" x-data="reader" @click="onClick">
-  <div id="text--content" class="md:text-xl mx-4 pb-16 lg:flex-1 md:max-w-xl"
+  {# w-full to avoid ugly rendering for long text on mobile. #}
+  <div class="px-4 pb-16 w-full md:max-w-xl"
       :class="getParseLayoutClasses">
   <div :class="fontSize">
 


### PR DESCRIPTION
Set an explicit width to prevent ugly rendering of long lines on mobile.

Test plan: tried it on dev.

Before:

<img width="383" alt="image" src="https://user-images.githubusercontent.com/1429776/194720595-27743264-aca5-4dbe-a8f7-104156a635c0.png">


After:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/1429776/194720607-2f6249b1-912d-4d82-b1ae-1d1b79943e0c.png">
