### PR TITLE
Fix typo in installation.rst (start-docker -> docker-start)

### DIFF
--- a/docs/creating-data-from-the-command-line.rst
+++ b/docs/creating-data-from-the-command-line.rst
@@ -10,7 +10,7 @@ Create a new user::
 
 Make that user an administrator::
 
-    ./cli.py add-role <username> admin
+    ./cli.py add-role --username <username> --role admin
 
 Create a fake proofing project::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -79,7 +79,7 @@ Docker setup (beta)
 This feature is still under development and may change. You can alternatively
 run a local development environment using Docker by running:
 
-    make start-docker
+    make docker-start
 
 
 Data dependencies

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,7 +15,7 @@ following command::
 Next, run the following commands to create a new admin user::
 
     ./cli.py create-user
-    ./cli.py add-role <username> admin
+    ./cli.py add-role --username <username> --role admin
 
 After that, you can bring up the development server::
 

--- a/scripts/install_from_scratch.sh
+++ b/scripts/install_from_scratch.sh
@@ -101,7 +101,7 @@ To create some sample data for our proofing interface, try the commands below.
 In these commands, arguments in <angle-brackets> must be supplied by you:
 
     ./cli.py create-user
-    ./cli.py add-role <username> admin
+    ./cli.py add-role --username <username> --role admin
     ./cli.py create-project <project-title> <path-to-project-pdf>
 
 To start the development server, run the following commands:


### PR DESCRIPTION
Use what's in the Makefile.