### PR TITLE
[proofing] Add partial work for search+replace

### DIFF
--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -15,12 +15,14 @@
 {{ m.project_nav(project=project, active='edit') }}
 
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
+{% set replace_url = url_for("proofing.project.replace", slug=project.slug)  %}
 {% set ocr_url = url_for("proofing.project.batch_ocr", slug=project.slug)  %}
 
 <div class="prose">
 
 <ul>
   <li><a href="{{ search_url }}">{{ _('Search the project') }}</a></li>
+  <li><a href="{{ replace_url }}">{{ _('Search & replace in the project') }}</a></li>
   <li><a href="{{ ocr_url }}">{{ _('Run batch OCR') }}</a></p>
 </ul>
 

--- a/ambuda/templates/proofing/projects/replace.html
+++ b/ambuda/templates/proofing/projects/replace.html
@@ -1,0 +1,47 @@
+{% extends 'proofing/base.html' %}
+{% from "macros/forms.html" import field %}
+{% import "macros/proofing.html" as m %}
+
+{% block title %}Search and Replace {{ project.title }} | Ambuda{% endblock %}
+
+{% block content %}
+
+{{ m.project_header_nested('Search and Replace', project) }}
+{{ m.project_nav(project=project, active='edit') }}
+
+<div class="prose">
+  <p>Use this simple search and replace form to make edits across this project.</p>
+</div>
+
+<form method="GET" class="bg-slate-100 p-4 my-4">
+  {{ field(form.query) }}
+  {{ field(form.replace) }}
+  <input class="btn btn-submit" type="submit" value="Project-wide Search & Replace">
+</form>
+
+{% if query %}
+<div class="prose">
+
+{% macro sp(s, p, n) %}{% if n == 1 %}{{ s }}{% else %}{{ p }}{% endif %}{% endmacro %}
+
+{% set nr = results|length %}
+<p>Found {{ nr }} {{ sp("page", "pages", nr) }} that {{ sp("contains", "contain", nr) }} <kbd>{{ query }}</kbd>.</p>
+
+<ul>
+{% for page in results %}
+{% set page_url = url_for("proofing.page.edit", project_slug=project.slug, page_slug=page.slug) %}
+<li>
+    <a href="{{ page_url }}">{{ project.title }}/{{ page.slug }}</a>
+    <div class="p-2 border-l my-2">
+    {% for match in page.matches %}
+    <pre class="p-0.5">{{ match.query }}</pre>
+    <pre class="p-0.5">{{ match.update }}</pre>
+    {%- endfor %}
+    </div>
+</li>
+{% endfor %}
+</ul>
+
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
* reset fork to upstream HEAD to address https://github.com/ambuda-org/ambuda/pull/452#issuecomment-1434178057
* re-applied changes for proofing project-wide `replace` words feature

## Tests

1. built container with make docker-start
2. checked Texts, Dictionaries, and Proofing pages.
3. tested `proofing > project > edit > search` page
4. tested `proofing > project > edit > search and replace` page

## To do

1. Test actual `search and replace`. I could not find a pre-existing text in db to test this feature.
2. add support in translation files
