### PR TITLE
Add validators for username, password, and email

### DIFF
--- a/ambuda/templates/proofing/projects/edit.html
+++ b/ambuda/templates/proofing/projects/edit.html
@@ -15,12 +15,14 @@
 {{ m.project_nav(project=project, active='edit') }}
 
 {% set search_url = url_for("proofing.project.search", slug=project.slug)  %}
+{% set replace_url = url_for("proofing.project.replace", slug=project.slug)  %}
 {% set ocr_url = url_for("proofing.project.batch_ocr", slug=project.slug)  %}
 
 <div class="prose">
 
 <ul>
   <li><a href="{{ search_url }}">{{ _('Search the project') }}</a></li>
+  <li><a href="{{ replace_url }}">{{ _('Search & replace in the project') }}</a></li>
   <li><a href="{{ ocr_url }}">{{ _('Run batch OCR') }}</a></p>
 </ul>
 

--- a/ambuda/templates/proofing/projects/replace.html
+++ b/ambuda/templates/proofing/projects/replace.html
@@ -1,0 +1,47 @@
+{% extends 'proofing/base.html' %}
+{% from "macros/forms.html" import field %}
+{% import "macros/proofing.html" as m %}
+
+{% block title %}Search and Replace {{ project.title }} | Ambuda{% endblock %}
+
+{% block content %}
+
+{{ m.project_header_nested('Search and Replace', project) }}
+{{ m.project_nav(project=project, active='edit') }}
+
+<div class="prose">
+  <p>Use this simple search and replace form to make edits across this project.</p>
+</div>
+
+<form method="GET" class="bg-slate-100 p-4 my-4">
+  {{ field(form.query) }}
+  {{ field(form.replace) }}
+  <input class="btn btn-submit" type="submit" value="Project-wide Search & Replace">
+</form>
+
+{% if query %}
+<div class="prose">
+
+{% macro sp(s, p, n) %}{% if n == 1 %}{{ s }}{% else %}{{ p }}{% endif %}{% endmacro %}
+
+{% set nr = results|length %}
+<p>Found {{ nr }} {{ sp("page", "pages", nr) }} that {{ sp("contains", "contain", nr) }} <kbd>{{ query }}</kbd>.</p>
+
+<ul>
+{% for page in results %}
+{% set page_url = url_for("proofing.page.edit", project_slug=project.slug, page_slug=page.slug) %}
+<li>
+    <a href="{{ page_url }}">{{ project.title }}/{{ page.slug }}</a>
+    <div class="p-2 border-l my-2">
+    {% for match in page.matches %}
+    <pre class="p-0.5">{{ match.query }}</pre>
+    <pre class="p-0.5">{{ match.update }}</pre>
+    {%- endfor %}
+    </div>
+</li>
+{% endfor %}
+</ul>
+
+</div>
+{% endif %}
+{% endblock %}

--- a/ambuda/views/auth.py
+++ b/ambuda/views/auth.py
@@ -117,12 +117,15 @@ def get_field_validators(field_name: str, min_len: int, max_len: int):
     ]
 
 
-def get_username_validators():
-    return [
+def get_username_validators(is_legacy: bool = False):
+    validators = [
         *get_field_validators("username", MIN_USERNAME_LEN, MAX_USERNAME_LEN),
-        val.Regexp("^[^\s]*$", message="Username must not contain spaces"),
     ]
-
+    if not is_legacy:
+        validators.append(
+            val.Regexp("^[^\s]*$", message="Username must not contain spaces")
+        )
+    return validators
 
 def get_password_validators():
     return [
@@ -158,7 +161,7 @@ class SignupForm(FlaskForm):
 
 
 class SignInForm(FlaskForm):
-    username = StringField(_l("Username"), [*get_username_validators()])
+    username = StringField(_l("Username"), [*get_username_validators(True)])
     password = PasswordField(_l("Password"), [*get_password_validators()])
 
 

--- a/ambuda/views/auth.py
+++ b/ambuda/views/auth.py
@@ -144,14 +144,14 @@ class SignupForm(FlaskForm):
     recaptcha = RecaptchaField()
 
     def validate_username(self, username):
-        # username is case insensitive
+        # TODO: make username case insensitive
         user = q.user(username.data)
         if user:
             raise val.ValidationError("Please use a different username.")
 
     def validate_email(self, email):
         session = q.get_session()
-        # email is case insensitive
+        # TODO: make email case insensitive
         user = session.query(db.User).filter_by(email=email.data).first()
         if user:
             raise val.ValidationError("Please use a different email address.")
@@ -215,7 +215,7 @@ def sign_in():
         return redirect(url_for("site.index"))
 
     form = SignInForm()
-    # username check is case insensitive
+    # TODO: make username case insensitive
     if form.validate_on_submit():
         user = q.user(form.username.data)
         if user and user.check_password(form.password.data):

--- a/ambuda/views/auth.py
+++ b/ambuda/views/auth.py
@@ -36,7 +36,7 @@ MIN_EMAIL_ADDRESS_LEN = 4
 MAX_EMAIL_ADDRESS_LEN = 254
 MIN_PASSWORD_LEN = 8
 MAX_PASSWORD_LEN = 256
-MIN_USERNAME_LEN= 6
+MIN_USERNAME_LEN = 6
 MAX_USERNAME_LEN = 64
 
 # token lifetime
@@ -90,36 +90,53 @@ def _is_valid_reset_token(row: db.PasswordResetToken, raw_token: str, now=None):
 
     return True
 
+
 # Copied from https://wtforms.readthedocs.io/en/2.3.x/validators/
 class FieldLength(object):
     def __init__(self, min=-1, max=-1, message=None):
         self.min = min
         self.max = max
         if not message:
-            message = u'Field must be between %i and %i characters long.' % (min, max)
+            message = "Field must be between %i and %i characters long." % (min, max)
         self.message = message
 
     def __call__(self, form, field):
-        l = field.data and len(field.data) or 0
-        if l < self.min or self.max != -1 and l > self.max:
+        field_len = field.data and len(field.data) or 0
+        if field_len < self.min or self.max != -1 and field_len > self.max:
             raise val.ValidationError(self.message)
 
 
 def get_field_validators(field_name: str, min_len: int, max_len: int):
     return [
         val.DataRequired(),
-        FieldLength(min=min_len, max=max_len, message=f"{field_name.capitalize()} must be between {min_len} and {max_len} characters long"),
+        FieldLength(
+            min=min_len,
+            max=max_len,
+            message=f"{field_name.capitalize()} must be between {min_len} and {max_len} characters long",
+        ),
     ]
 
+
 class SignupForm(FlaskForm):
-    username = StringField(_l("Username"), [*get_field_validators("username", MIN_USERNAME_LEN, MAX_USERNAME_LEN),
-                                            val.Regexp('^[^\s]*$', message="Username must not contain spaces"), 
-                                            ]
+    username = StringField(
+        _l("Username"),
+        [
+            *get_field_validators("username", MIN_USERNAME_LEN, MAX_USERNAME_LEN),
+            val.Regexp("^[^\s]*$", message="Username must not contain spaces"),
+        ],
     )
-    password = PasswordField(_l("Password"), [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)])
-    email = StringField(_l("Email address"), [*get_field_validators("email address", MIN_EMAIL_ADDRESS_LEN, MAX_EMAIL_ADDRESS_LEN),
-                                              val.Email(),
-                                             ]
+    password = PasswordField(
+        _l("Password"),
+        [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)],
+    )
+    email = StringField(
+        _l("Email address"),
+        [
+            *get_field_validators(
+                "email address", MIN_EMAIL_ADDRESS_LEN, MAX_EMAIL_ADDRESS_LEN
+            ),
+            val.Email(),
+        ],
     )
     recaptcha = RecaptchaField()
 
@@ -138,17 +155,28 @@ class SignupForm(FlaskForm):
 
 
 class SignInForm(FlaskForm):
-    username = StringField(_l("Username"), [*get_field_validators("username", MIN_USERNAME_LEN, MAX_USERNAME_LEN), 
-                                            val.Regexp('^[^\s]*$', message="Username must not contain spaces"),
-                                            ]
+    username = StringField(
+        _l("Username"),
+        [
+            *get_field_validators("username", MIN_USERNAME_LEN, MAX_USERNAME_LEN),
+            val.Regexp("^[^\s]*$", message="Username must not contain spaces"),
+        ],
     )
-    password = PasswordField(_l("Password"), [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)])
+    password = PasswordField(
+        _l("Password"),
+        [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)],
+    )
 
 
 class ResetPasswordForm(FlaskForm):
-    email = EmailField("Email", [*get_field_validators("email address", MIN_EMAIL_ADDRESS_LEN, MAX_EMAIL_ADDRESS_LEN),
-                                 val.Email(),
-                                ]
+    email = EmailField(
+        "Email",
+        [
+            *get_field_validators(
+                "email address", MIN_EMAIL_ADDRESS_LEN, MAX_EMAIL_ADDRESS_LEN
+            ),
+            val.Email(),
+        ],
     )
     recaptcha = RecaptchaField()
 
@@ -156,14 +184,26 @@ class ResetPasswordForm(FlaskForm):
 class ChangePasswordForm(FlaskForm):
     #: Old password. No validation requirements, in case we change our password
     #: criteria in the future.
-    old_password = PasswordField(_l("Old password"), [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)])
+    old_password = PasswordField(
+        _l("Old password"),
+        [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)],
+    )
     #: New password.
-    new_password = PasswordField(_l("New password"), [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)])
+    new_password = PasswordField(
+        _l("New password"),
+        [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)],
+    )
 
 
 class ResetPasswordFromTokenForm(FlaskForm):
-    password = PasswordField(_l("Password"), [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)])
-    confirm_password = PasswordField(_l("Confirm password"), [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)])
+    password = PasswordField(
+        _l("Password"),
+        [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)],
+    )
+    confirm_password = PasswordField(
+        _l("Confirm password"),
+        [*get_field_validators("password", MIN_PASSWORD_LEN, MAX_PASSWORD_LEN)],
+    )
 
 
 @bp.route("/register", methods=["GET", "POST"])

--- a/ambuda/views/auth.py
+++ b/ambuda/views/auth.py
@@ -90,11 +90,25 @@ def _is_valid_reset_token(row: db.PasswordResetToken, raw_token: str, now=None):
 
     return True
 
+# Copied from https://wtforms.readthedocs.io/en/2.3.x/validators/
+class FieldLength(object):
+    def __init__(self, min=-1, max=-1, message=None):
+        self.min = min
+        self.max = max
+        if not message:
+            message = u'Field must be between %i and %i characters long.' % (min, max)
+        self.message = message
+
+    def __call__(self, form, field):
+        l = field.data and len(field.data) or 0
+        if l < self.min or self.max != -1 and l > self.max:
+            raise val.ValidationError(self.message)
+
 
 def get_field_validators(field_name: str, min_len: int, max_len: int):
     return [
         val.DataRequired(),
-        val.Length(min=min_len, max=max_len, message=f"{field_name.capitalize()} must be between {min_len} and {max_len} characters long"),
+        FieldLength(min=min_len, max=max_len, message=f"{field_name.capitalize()} must be between {min_len} and {max_len} characters long"),
     ]
 
 class SignupForm(FlaskForm):

--- a/ambuda/views/auth.py
+++ b/ambuda/views/auth.py
@@ -80,11 +80,16 @@ def _is_valid_reset_token(row: db.PasswordResetToken, raw_token: str, now=None):
 
 
 class SignupForm(FlaskForm):
-    username = StringField(
-        _l("Username"), [val.Length(min=6, max=25), val.DataRequired()]
+    username = StringField(_l("Username"), [val.DataRequired(), 
+                                            val.Regexp('^[^\s]*$', message="Username must not contain spaces"),
+                                            val.Length(min=6, max=25, message="Username must be between 6 and 25 characters long"), ]
     )
-    password = PasswordField(_l("Password"), [val.Length(min=8), val.DataRequired()])
-    email = StringField(_l("Email address"), [val.DataRequired(), val.Email()])
+    password = PasswordField(_l("Password"), [val.DataRequired(),
+                                              val.Length(min=8, max=64, message="Password must be between 8 and 64 characters long"), ]
+    )
+    email = StringField(_l("Email address"), [val.DataRequired(), 
+                                              val.Length(max=128, message="Email address cannot exceed 128 characters"),
+                                              val.Email()])
     recaptcha = RecaptchaField()
 
     def validate_username(self, username):
@@ -100,14 +105,17 @@ class SignupForm(FlaskForm):
 
 
 class SignInForm(FlaskForm):
-    username = StringField(
-        _l("Username"), [val.Length(min=6, max=25), val.DataRequired()]
+    username = StringField(_l("Username"), [val.DataRequired(), 
+                                            val.Regexp('^[^\s]*$', message="Username must not contain spaces"),
+                                            val.Length(min=6, max=25, message="Username must be between 6 and 25 characters long"), ]
     )
-    password = PasswordField(_l("Password"), [val.Length(min=8), val.DataRequired()])
+    password = PasswordField(_l("Password"), [val.DataRequired(),
+                                              val.Length(min=8, max=64, message="Password must be between 8 and 64 characters long"), ]
+    )
 
 
 class ResetPasswordForm(FlaskForm):
-    email = EmailField("Email", [val.DataRequired()])
+    email = EmailField("Email", [val.DataRequired(), ])
     recaptcha = RecaptchaField()
 
 


### PR DESCRIPTION
Added validators for username, password, and email addresses to address https://github.com/ambuda-org/ambuda/issues/454.

1. username validator now checks for spaces and upper bound on length is 64.
2. a password validator puts 256 as an upper bound on length. Otherwise, to avert any memory overruns by a malicious user or due to an unintentional error.
3. email address validator puts 254 as an upper bound on length.  
4. username and email addresses are now case insensitive

## Tests
1. normal login works
3. check sign-in with a username containing spaces fails

![Screenshot 2023-02-20 at 5 16 12 PM](https://user-images.githubusercontent.com/44282098/220206288-b97c32ce-8c73-4dab-bc54-36b41058c29c.png)

## To Do
1. check `Register` with a username containing space fails. I could not check as captcha is coming in the way. Don't know how to bypass it on a local machine.
2. translation files have to update.
 