### PR TITLE
Fix broken data source for shabdartha_kaustubha

### DIFF
--- a/ambuda/seed/dictionaries/shabdartha_kaustubha.py
+++ b/ambuda/seed/dictionaries/shabdartha_kaustubha.py
@@ -27,7 +27,7 @@ from ambuda.seed.utils.cdsl_utils import create_from_scratch
 from ambuda.seed.utils.data_utils import create_db, fetch_text
 from ambuda.utils.dict_utils import standardize_key
 
-RAW_URL = "https://raw.githubusercontent.com/indic-dict/stardict-sanskrit/raw/master/sa-head/other-indic-entries/shabdArtha_kaustubha/shabdArtha_kaustubha.babylon"
+RAW_URL = "https://raw.githubusercontent.com/indic-dict/stardict-sanskrit/master/sa-head/other-indic-entries/shabdArtha_kaustubha/shabdArtha_kaustubha.babylon"
 
 
 def create_entries(key: str, body: str) -> Iterator[tuple[str, str]]:


### PR DESCRIPTION
It looks like GitHub changed their URL structure for accessing raw files so the link was updated to not return a 404.