### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/ambuda/templates/htmx/parsed-tokens.html
+++ b/ambuda/templates/htmx/parsed-tokens.html
@@ -1,1 +1,1 @@
-{{ aligned | safe}}
+{{ aligned }}

--- a/ambuda/templates/htmx/text-block.html
+++ b/ambuda/templates/htmx/text-block.html
@@ -1,3 +1,3 @@
-<s-block data-slug="{{ slug }}>
-  {{ html | safe }}
+<s-block data-slug="{{ slug }}">
+  {{ html }}
 </s-block>


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `ambuda/templates/htmx/parsed-tokens.html:L1`

The template renders `aligned` directly with `|safe`, which disables Jinja auto-escaping. If `aligned` can contain user-controlled or externally sourced content (directly or indirectly), attackers can inject arbitrary HTML/JS and execute script in users' browsers.

## Solution

Avoid `|safe` for untrusted content. Sanitize HTML server-side with a strict allowlist (e.g., Bleach) before rendering, or render as escaped text. If rich formatting is required, define a minimal allowed tag/attribute set and strip scripts/event handlers/unsafe URLs.

## Changes

- `ambuda/templates/htmx/parsed-tokens.html` (modified)
- `ambuda/templates/htmx/text-block.html` (modified)